### PR TITLE
feat: disable selfdestruct opcode in MiniRex spec

### DIFF
--- a/crates/mega-evm/src/instructions.rs
+++ b/crates/mega-evm/src/instructions.rs
@@ -17,6 +17,10 @@ use revm::{
 };
 
 /// `MegaethInstructions` is the instruction table for `MegaETH`.
+///
+/// This instruction table customizes certain opcodes for `MegaETH` specifications:
+/// - LOG opcodes with quadratic data cost after Mini-Rex
+/// - SELFDESTRUCT opcode disabled after Mini-Rex to prevent contract destruction
 #[derive(Clone)]
 pub struct Instructions<DB: Database> {
     spec: SpecId,
@@ -44,7 +48,9 @@ impl<DB: Database> Instructions<DB> {
             self.inner.insert_instruction(LOG2, log_with_quadratic_data_cost::<2, _>);
             self.inner.insert_instruction(LOG3, log_with_quadratic_data_cost::<3, _>);
             self.inner.insert_instruction(LOG4, log_with_quadratic_data_cost::<4, _>);
-            // Disallow SELFDESTRUCT opcode
+            // Disallow SELFDESTRUCT opcode in Mini-Rex spec
+            // This prevents contracts from being permanently destroyed
+            // When executed, it will halt with InvalidFEOpcode
             self.inner.insert_instruction(SELFDESTRUCT, control::invalid);
         }
         self

--- a/crates/mega-evm/src/lib.rs
+++ b/crates/mega-evm/src/lib.rs
@@ -354,7 +354,7 @@ mod tests {
 
         use crate::{set_account_code, transact, HaltReason, SpecId, TransactionError};
 
-        /// SELFDESTRUCT is allowed before mini-rex
+        /// Test that SELFDESTRUCT opcode works normally before Mini-Rex
         #[test]
         fn test_selfdestruct_allowed_before_mini_rex() {
             let mut db = CacheDB::<EmptyDB>::default();
@@ -376,7 +376,8 @@ mod tests {
             assert_eq!(result.unwrap().result.gas_used(), 26004);
         }
 
-        /// SELFDESTRUCT is disallowed and treated as INVALID after mini-rex
+        /// Test that SELFDESTRUCT opcode is disabled and returns `InvalidFEOpcode` after Mini-Rex
+        /// hardfork
         #[test]
         fn test_selfdestruct_disallowed_after_mini_rex() {
             let mut db = CacheDB::<EmptyDB>::default();


### PR DESCRIPTION
## feat: disable selfdestruct after mini-rex

Disables the `SELFDESTRUCT` opcode in the MegaETH EVM after the Mini-Rex hardfork by replacing it with an invalid instruction.

### Changes
- **Instructions**: Replace `SELFDESTRUCT` with `control::invalid` when Mini-Rex spec is active
- **Testing**: Added tests to verify `SELFDESTRUCT` works before Mini-Rex and fails after
- **Dependencies**: Upgraded to revm v27.1.0 and latest alloy packages

### Impact
- Prevents contract self-destruction after Mini-Rex hardfork
- Maintains backward compatibility for pre-Mini-Rex contracts
- Minimal performance overhead