### PR TITLE
fix: set receipt status based on execution result and exclude logs on failure

### DIFF
--- a/bin/mega-evme/src/t8n/cmd.rs
+++ b/bin/mega-evme/src/t8n/cmd.rs
@@ -204,7 +204,8 @@ impl Cmd {
                     total_gas_used += tx_gas_used;
 
                     // Determine if execution was successful based on execution result type
-                    let is_success = matches!(result, revm::context::result::ExecutionResult::Success { .. });
+                    let is_success =
+                        matches!(result, revm::context::result::ExecutionResult::Success { .. });
 
                     // Only add logs if execution was successful
                     if is_success {


### PR DESCRIPTION
## Summary
- Set transaction receipt status to 0 on execution failure instead of always 1
- Exclude logs from receipts when transaction execution fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)