### PR TITLE
refactor: rename oracle address constant and add solidity interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2174,6 +2174,7 @@ dependencies = [
  "alloy-op-evm",
  "alloy-op-hardforks",
  "alloy-primitives",
+ "alloy-sol-types",
  "auto_impl",
  "bitflags",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,7 @@ alloy-op-hardforks = "0.2.2"
 alloy-primitives = { version = "1.3.0", default-features = false, features = ["map-foldhash"] }
 alloy-rlp = { version = "0.3.12", default-features = false }
 alloy-serde = { version = "1.0.23", default-features = false }
+alloy-sol-types = { version = "1.0.23" }
 op-alloy-consensus = { version = "0.18.12", default-features = false }
 
 # misc

--- a/crates/mega-evm/Cargo.toml
+++ b/crates/mega-evm/Cargo.toml
@@ -19,6 +19,7 @@ alloy-evm.workspace = true
 alloy-op-evm.workspace = true
 alloy-op-hardforks.workspace = true
 alloy-primitives.workspace = true
+alloy-sol-types.workspace = true
 op-alloy-consensus.workspace = true
 
 # megaeth

--- a/crates/mega-evm/src/access/oracle.rs
+++ b/crates/mega-evm/src/access/oracle.rs
@@ -10,9 +10,6 @@ use alloy_primitives::Address;
 
 use crate::ORACLE_CONTRACT_ADDRESS;
 
-/// The address of the `MegaETH`'s oracle contract.
-pub const MEGA_ORACLE_CONTRACT_ADDRESS: Address = ORACLE_CONTRACT_ADDRESS;
-
 /// A tracker for oracle data access.
 #[derive(Default, Debug, Clone)]
 pub struct OracleAccessTracker {
@@ -28,7 +25,7 @@ impl OracleAccessTracker {
     /// Checks if the given address is the oracle contract address. If so, it will mark that the
     /// oracle has been accessed and returns true.
     pub fn check_and_mark_oracle_access(&mut self, address: &Address) -> bool {
-        if address == &MEGA_ORACLE_CONTRACT_ADDRESS {
+        if address == &ORACLE_CONTRACT_ADDRESS {
             self.accessed = true;
             true
         } else {

--- a/crates/mega-evm/src/external/mod.rs
+++ b/crates/mega-evm/src/external/mod.rs
@@ -7,13 +7,11 @@ use alloy_primitives::{BlockNumber, U256};
 use auto_impl::auto_impl;
 use revm::primitives::HashMap;
 
-use crate::{
-    oracle::OracleEnv,
-    salt::{BucketId, SaltEnv},
-};
+mod oracle;
+mod salt;
 
-pub mod oracle;
-pub mod salt;
+pub use oracle::*;
+pub use salt::*;
 
 /// A collection trait that aggregates all external environments needed by the EVM.
 ///

--- a/crates/mega-evm/src/gas.rs
+++ b/crates/mega-evm/src/gas.rs
@@ -4,10 +4,7 @@ use std::collections::hash_map::Entry;
 use alloy_primitives::{Address, BlockNumber, B256, U256};
 use revm::{context::BlockEnv, primitives::HashMap};
 
-use crate::{
-    constants,
-    salt::{BucketId, SaltEnv},
-};
+use crate::{constants, BucketId, SaltEnv};
 
 /// Calculator for dynamic gas costs based on bucket capacity.
 #[derive(Debug)]

--- a/crates/mega-evm/src/host.rs
+++ b/crates/mega-evm/src/host.rs
@@ -2,8 +2,8 @@ use core::cell::RefCell;
 use std::rc::Rc;
 
 use crate::{
-    oracle::OracleEnv, salt::SaltEnv, AdditionalLimit, BlockEnvAccess, ExternalEnvs, MegaContext,
-    MegaSpecId, VolatileDataAccessTracker, MEGA_ORACLE_CONTRACT_ADDRESS,
+    AdditionalLimit, BlockEnvAccess, ExternalEnvs, MegaContext, MegaSpecId, OracleEnv, SaltEnv,
+    VolatileDataAccessTracker, ORACLE_CONTRACT_ADDRESS,
 };
 use alloy_evm::Database;
 use alloy_primitives::{Address, Bytes, Log, B256, U256};
@@ -86,7 +86,7 @@ impl<DB: Database, ExtEnvs: ExternalEnvs> Host for MegaContext<DB, ExtEnvs> {
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>> {
-        if self.spec.is_enabled(MegaSpecId::MINI_REX) && address == MEGA_ORACLE_CONTRACT_ADDRESS {
+        if self.spec.is_enabled(MegaSpecId::MINI_REX) && address == ORACLE_CONTRACT_ADDRESS {
             // if the oracle env provides a value, return it. Otherwise, fallback to the inner
             // context.
             if let Some(value) = self.oracle_env.borrow().get_oracle_storage(key) {

--- a/crates/mega-evm/src/system/oracle.rs
+++ b/crates/mega-evm/src/system/oracle.rs
@@ -1,7 +1,10 @@
-//! The oracle system contract for the `MegaETH` EVM.
+//! The oracle system contract for the `MegaETH` EVM. The oracle contract is implemented in
+//! `../../system-contracts/src/Oracle.sol`.
 
 use alloy_evm::Database;
 use alloy_primitives::{address, b256, bytes, Address, Bytes, B256};
+use alloy_sol_types::sol;
+pub use alloy_sol_types::SolCall;
 use revm::{
     database::State,
     state::{Bytecode, EvmState},
@@ -18,6 +21,16 @@ pub const ORACLE_CONTRACT_CODE: Bytes =
 /// The code hash of the oracle contract.
 pub const ORACLE_CONTRACT_CODE_HASH: B256 =
     b256!("0x76d9dee8ee8b8353378ede74ddd42258907f7eccce4691c37ac7d69d4ef4e0a8");
+
+sol! {
+    /// The Solidity interface for the oracle contract.
+    interface Oracle {
+        function getSlot(bytes32 slot) external view returns (bytes32 value);
+        function setSlot(bytes32 slot, bytes32 value) external;
+        function getSlots(bytes32[] calldata slots) external view returns (bytes32[] memory values);
+        function setSlots(bytes32[] calldata slots, bytes32[] calldata values) external;
+    }
+}
 
 /// Deploys the oracle contract in the designated address and returns the state changes. Note that
 /// the database `db` is not modified in this function. The caller is responsible to commit the

--- a/crates/mega-evm/tests/oracle.rs
+++ b/crates/mega-evm/tests/oracle.rs
@@ -6,7 +6,7 @@ use mega_evm::{
     constants::mini_rex::VOLATILE_DATA_ACCESS_REMAINING_GAS,
     test_utils::{BytecodeBuilder, GasInspector, MemoryDatabase, MsgCallMeta},
     DefaultExternalEnvs, MegaContext, MegaEvm, MegaSpecId, MegaTransaction,
-    MEGA_ORACLE_CONTRACT_ADDRESS,
+    ORACLE_CONTRACT_ADDRESS,
 };
 use revm::{
     bytecode::opcode::{
@@ -69,7 +69,7 @@ fn test_oracle_access_detected_on_call() {
     let bytecode = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .stop()
@@ -135,7 +135,7 @@ fn test_oracle_access_not_detected_in_equivalence_spec() {
     let bytecode = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .stop()
@@ -159,7 +159,7 @@ fn test_oracle_access_detected_with_explicit_zero_value() {
     let bytecode = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei (explicit)
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .stop()
@@ -182,11 +182,11 @@ fn test_oracle_access_detected_on_multiple_calls() {
     let bytecode = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args again
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract again
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract again
         .append(GAS)
         .append(CALL)
         .stop()
@@ -212,7 +212,7 @@ fn test_oracle_access_limits_parent_gas() {
     let intermediate_code = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .push_number(0u8)
@@ -264,7 +264,7 @@ fn test_oracle_access_limits_parent_gas() {
             } else {
                 match &node.borrow().meta {
                     MsgCallMeta::Call(call_inputs) => {
-                        if call_inputs.target_address == MEGA_ORACLE_CONTRACT_ADDRESS {
+                        if call_inputs.target_address == ORACLE_CONTRACT_ADDRESS {
                             accessed = true;
                         }
                     }
@@ -287,7 +287,7 @@ fn test_parent_runs_out_of_gas_after_oracle_access() {
     builder = builder
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0])
         .push_number(0u8)
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS)
+        .push_address(ORACLE_CONTRACT_ADDRESS)
         .append(GAS)
         .append(CALL);
     // After the call returns, the left gas is limited to 10k
@@ -417,7 +417,7 @@ fn test_oracle_contract_code_subject_to_gas_limit() {
     let main_code = BytecodeBuilder::default()
         .append_many([PUSH0, PUSH0, PUSH0, PUSH0]) // return memory args
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS)
         .append(CALL)
         .append_many([SLOAD, SLOAD, SLOAD, SLOAD, SLOAD, SLOAD])
@@ -426,8 +426,8 @@ fn test_oracle_contract_code_subject_to_gas_limit() {
 
     let mut db = MemoryDatabase::default();
     db.set_account_code(CALLEE, main_code);
-    db.set_account_storage(MEGA_ORACLE_CONTRACT_ADDRESS, U256::ZERO, U256::from(0x2333u64));
-    db.set_account_code(MEGA_ORACLE_CONTRACT_ADDRESS, oracle_code);
+    db.set_account_storage(ORACLE_CONTRACT_ADDRESS, U256::ZERO, U256::from(0x2333u64));
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
 
     let external_envs = DefaultExternalEnvs::<std::convert::Infallible>::new();
     let mut gas_inspector = GasInspector::new();
@@ -455,7 +455,7 @@ fn test_oracle_contract_code_subject_to_gas_limit() {
         |_node_location, node, _item_location, item| {
             match &node.borrow().meta {
                 MsgCallMeta::Call(call_inputs) => {
-                    if call_inputs.target_address == MEGA_ORACLE_CONTRACT_ADDRESS {
+                    if call_inputs.target_address == ORACLE_CONTRACT_ADDRESS {
                         inside_oracle = true;
                     }
                 }
@@ -496,7 +496,7 @@ fn test_oracle_storage_sload_uses_oracle_env() {
         .push_number(0u8) // argsSize for CALL
         .push_number(0u8) // argsOffset for CALL
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS) // gas
         .append(CALL) // execute the call
         .append(PUSH0) // pop the call result (success/fail)
@@ -514,7 +514,7 @@ fn test_oracle_storage_sload_uses_oracle_env() {
     // Set up the oracle environment with the test storage value
     let mut db = MemoryDatabase::default();
     db.set_account_code(CALLEE, main_code);
-    db.set_account_code(MEGA_ORACLE_CONTRACT_ADDRESS, oracle_code);
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
 
     let external_envs = DefaultExternalEnvs::<std::convert::Infallible>::new()
         .with_oracle_storage(test_slot, oracle_value);
@@ -559,7 +559,7 @@ fn test_oracle_storage_sload_fallback_to_database() {
         .push_number(0u8) // argsSize for CALL
         .push_number(0u8) // argsOffset for CALL
         .push_number(0u8) // value: 0 wei
-        .push_address(MEGA_ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
+        .push_address(ORACLE_CONTRACT_ADDRESS) // callee: oracle contract
         .append(GAS) // gas
         .append(CALL) // execute the call
         .append(PUSH0) // pop the call result (success/fail)
@@ -577,8 +577,8 @@ fn test_oracle_storage_sload_fallback_to_database() {
     // Set up database with a storage value for the oracle contract
     let mut db = MemoryDatabase::default();
     db.set_account_code(CALLEE, main_code);
-    db.set_account_code(MEGA_ORACLE_CONTRACT_ADDRESS, oracle_code);
-    db.set_account_storage(MEGA_ORACLE_CONTRACT_ADDRESS, test_slot, db_value);
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
+    db.set_account_storage(ORACLE_CONTRACT_ADDRESS, test_slot, db_value);
 
     // Create external envs WITHOUT setting oracle storage (so it returns None)
     let external_envs = DefaultExternalEnvs::<std::convert::Infallible>::new();
@@ -617,7 +617,7 @@ fn test_oracle_storage_sload_direct_call() {
 
     // Set up the oracle environment with the test storage value
     let mut db = MemoryDatabase::default();
-    db.set_account_code(MEGA_ORACLE_CONTRACT_ADDRESS, oracle_code);
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
 
     let external_envs = DefaultExternalEnvs::<std::convert::Infallible>::new()
         .with_oracle_storage(test_slot, oracle_value);
@@ -628,7 +628,7 @@ fn test_oracle_storage_sload_direct_call() {
         &mut db,
         &external_envs,
         None,
-        MEGA_ORACLE_CONTRACT_ADDRESS,
+        ORACLE_CONTRACT_ADDRESS,
     );
 
     // Verify the transaction succeeded


### PR DESCRIPTION
## Summary
- Renamed `MEGA_ORACLE_CONTRACT_ADDRESS` to `ORACLE_CONTRACT_ADDRESS` for consistency
- Added `alloy-sol-types` dependency and Solidity interface definitions for type-safe oracle contract interactions
- Refactored `external/mod.rs` module visibility to use re-exports

## Changes
- Updated all references to oracle contract address constant
- Added Oracle Solidity interface with methods: `getSlot`, `setSlot`, `getSlots`, `setSlots`
- Made oracle and salt modules private in external module and re-exported their types
- Updated documentation for oracle system contract