### PR TITLE
feat: reduce code deposit cost from ~62,500 to 10,000 gas per byte

### DIFF
--- a/ARCH.md
+++ b/ARCH.md
@@ -94,7 +94,7 @@ self.inner.insert_instruction(SELFDESTRUCT, control::invalid);
 **Limits**:
 - `MAX_CONTRACT_SIZE`: 512 KB (vs standard 24 KB) - ~21x increase
 - `MAX_INITCODE_SIZE`: 536 KB (512 KB + 24 KB buffer) - ~11x increase
-- `CODEDEPOSIT_COST`: ~62,500 gas per byte (vs 200) - ~312x increase
+- `CODEDEPOSIT_COST`: 10,000 gas per byte (vs 200) - 50x increase
 
 #### Data and KV Update Limits
 

--- a/crates/mega-evm/src/constants.rs
+++ b/crates/mega-evm/src/constants.rs
@@ -39,9 +39,9 @@ pub mod mini_rex {
     /// Applied to both CREATE and CREATE2 operations.
     pub const CREATE_GAS: u64 = 2_000_000;
     /// Additional gas cost per byte for code deposit during contract creation in `MINI_REX` spec.
-    /// Total cost per byte: ~62,500 gas (200 standard + 62,300 additional).
-    /// Formula: `2_000_000 / 32 - CODEDEPOSIT` where CODEDEPOSIT = 200.
-    pub const CODEDEPOSIT_ADDITIONAL_GAS: u64 = 2_000_000 / 32 - super::equivalence::CODEDEPOSIT;
+    /// Total cost per byte: 10,000 gas (200 standard + 9,800 additional).
+    /// Formula: `10_000 - CODEDEPOSIT` where CODEDEPOSIT = 200.
+    pub const CODEDEPOSIT_ADDITIONAL_GAS: u64 = 10_000 - super::equivalence::CODEDEPOSIT;
     /// The gas cost for `LOGDATA` for the `MINI_REX` spec, i.e., gas cost per byte for log data.
     pub const LOG_DATA_GAS: u64 = super::equivalence::LOGDATA * 10;
     /// The gas cost for `LOGTOPIC` for the `MINI_REX` spec, i.e., gas cost per topic for log.

--- a/hardfork-spec/MiniRex.md
+++ b/hardfork-spec/MiniRex.md
@@ -8,7 +8,7 @@
 | **SSTORE (other cases)**                                 | EIP-2200 rules (reset, same, refund, warm read)    | Same as standard                                                                             |
 | **New account (CALL → empty, tx callee, CREATE target)** | 25,000 (NEWACCOUNT)                                | **2,000,000 × bucket multiplier**                                                            |
 | **Contract creation (CREATE/CREATE2)**                   | 25,000 (new account) + code deposit gas            | **2,000,000 × multiplier (new acct)** + **2,000,000 (codehash)** + code deposit gas          |
-| **Code deposit (per byte)**                              | 200 gas/byte                                       | **62,500 gas/byte**                                                                          |
+| **Code deposit (per byte)**                              | 200 gas/byte                                       | **10,000 gas/byte**                                                                          |
 | **Initcode max size**                                    | 49152 bytes (per EIP-3860)                         | **MAX_CONTRACT_SIZE (512 KiB) + 24 KiB**                                                     |
 | **CREATE/CALL forwarding fraction**                      | 63/64 of gas left                                  | **98/100** of gas left                                                                       |
 | **LOG per topic**                                        | 375 gas/topic                                      | **3,750 gas/topic (×10)**                                                                    |
@@ -108,9 +108,9 @@ This document details all semantic changes, their rationale, and implementation 
 
 **Per-Byte Cost:**
 
-- **MiniRex Cost**: 62,500 gas per byte
+- **MiniRex Cost**: 10,000 gas per byte (200 standard + 9,800 additional)
 - **Standard EVM**: 200 gas per byte
-- **Calculation**: `CREATE_GAS / 32 = 2_000_000 / 32 = 62,500`
+- **Constant**: `CODEDEPOSIT_ADDITIONAL_GAS = 10_000 - CODEDEPOSIT` where CODEDEPOSIT = 200
 - **Purpose**: Prevent unsustainable state bloat
 
 #### 3.3.4 Logging Operations


### PR DESCRIPTION
## Summary
- Reduced code deposit cost from ~62,500 gas to 10,000 gas per byte
- Changed CODEDEPOSIT_ADDITIONAL_GAS formula from `(2_000_000 / 32 - CODEDEPOSIT)` to `(10_000 - CODEDEPOSIT)`
- Updated documentation in MiniRex.md to reflect the new formula and cost breakdown

## Changes
- **constants.rs**: Updated CODEDEPOSIT_ADDITIONAL_GAS formula and comments
- **MiniRex.md**: Added constant formula and clarified cost breakdown (200 standard + 9,800 additional)

## Impact
This change reduces the gas cost for deploying contract code, making contract deployment more affordable while still maintaining the 50x increase over standard EVM costs.