### PR TITLE
refactor: remove is_first_mini_rex_block parameter and rename deploy function

### DIFF
--- a/crates/mega-evm/src/system/oracle.rs
+++ b/crates/mega-evm/src/system/oracle.rs
@@ -32,10 +32,12 @@ sol! {
     }
 }
 
-/// Deploys the oracle contract in the designated address and returns the state changes. Note that
-/// the database `db` is not modified in this function. The caller is responsible to commit the
-/// changes to database.
-pub fn deploy_oracle_contract<DB: Database>(db: &mut State<DB>) -> Result<EvmState, DB::Error> {
+/// Ensures the oracle contract is deployed in the designated address and returns the state changes.
+/// Note that the database `db` is not modified in this function. The caller is responsible to
+/// commit the changes to database.
+pub fn ensure_oracle_contract_deployed<DB: Database>(
+    db: &mut State<DB>,
+) -> Result<EvmState, DB::Error> {
     // Load the oracle contract account from the cache
     let acc = db.load_cache_account(ORACLE_CONTRACT_ADDRESS)?;
 
@@ -82,7 +84,8 @@ mod tests {
         let mut state = State::builder().with_database(&mut db).build();
 
         // Deploy the oracle contract
-        let result = deploy_oracle_contract(&mut state).expect("Deployment should succeed");
+        let result =
+            ensure_oracle_contract_deployed(&mut state).expect("Deployment should succeed");
 
         // Verify that state changes were returned
         assert_eq!(result.len(), 1, "Should have state changes for one account");
@@ -128,7 +131,8 @@ mod tests {
         let mut state = State::builder().with_database(&mut db).build();
 
         // Deploy should return empty state (no changes needed)
-        let result = deploy_oracle_contract(&mut state).expect("Deployment should succeed");
+        let result =
+            ensure_oracle_contract_deployed(&mut state).expect("Deployment should succeed");
         assert_eq!(
             result.len(),
             0,
@@ -158,7 +162,8 @@ mod tests {
         let mut state = State::builder().with_database(&mut db).build();
 
         // Deploy should update the contract with correct code
-        let result = deploy_oracle_contract(&mut state).expect("Deployment should succeed");
+        let result =
+            ensure_oracle_contract_deployed(&mut state).expect("Deployment should succeed");
 
         // Verify that state changes were returned (contract was updated)
         assert_eq!(result.len(), 1, "Should have state changes to update the contract");
@@ -178,7 +183,8 @@ mod tests {
         let mut state = State::builder().with_database(&mut db).build();
 
         // Deploy the oracle contract
-        let result = deploy_oracle_contract(&mut state).expect("Deployment should succeed");
+        let result =
+            ensure_oracle_contract_deployed(&mut state).expect("Deployment should succeed");
 
         // Get the account from result
         let account = result.get(&ORACLE_CONTRACT_ADDRESS).expect("Account should exist in result");

--- a/crates/mega-evm/tests/block_executor.rs
+++ b/crates/mega-evm/tests/block_executor.rs
@@ -141,7 +141,7 @@ fn test_block_default_limits_applied() {
     let evm = evm_factory.create_evm(&mut state, evm_env);
 
     // Create block context with default limits
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false);
+    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new());
 
     // Verify default limits are set
     assert_eq!(block_ctx.block_data_limit, BLOCK_DATA_LIMIT);
@@ -199,7 +199,7 @@ fn test_block_custom_data_limit() {
     // We set limit low enough that 2 transactions will exceed it
     // Using builder pattern to set only the data limit
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_data_limit(2_500); // 2.5 KB data limit - should fit 1 tx but not 2
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_data_limit(2_500); // 2.5 KB data limit - should fit 1 tx but not 2
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -260,7 +260,7 @@ fn test_block_custom_kv_update_limit() {
     // Set limit to 0 to ensure first transaction exceeds it
     // Using builder pattern to set only the KV limit
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_kv_update_limit(0); // Zero limit - any transaction will exceed
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_kv_update_limit(0); // Zero limit - any transaction will exceed
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -309,7 +309,7 @@ fn test_block_multiple_transactions_within_limits() {
     let evm = evm_factory.create_evm(&mut state, evm_env);
 
     // Create block context with reasonable limits
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false)
+    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new())
         .with_data_limit(10_000) // 10 KB data limit
         .with_kv_update_limit(1_000); // 1000 KV update limit
 
@@ -366,7 +366,7 @@ fn test_block_data_limit_exceeded_mid_block() {
 
     // Create block context with ~6 KB limit (should fit 2 transactions but not 3)
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_data_limit(6_000); // 6 KB data limit
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_data_limit(6_000); // 6 KB data limit
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -427,7 +427,7 @@ fn test_block_kv_limit_exceeded_mid_block() {
     // This should allow exactly 2 transaction to succeed (each transaction induces 2 KV updates,
     // sender account info and storage slot)
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_kv_update_limit(4); // 2 KV update limit - should fit 2 txs but not 3
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_kv_update_limit(4); // 2 KV update limit - should fit 2 txs but not 3
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -497,7 +497,7 @@ fn test_block_no_state_commit_on_limit_exceeded() {
     // Create block context with VERY low KV update limit (1 update)
     // This should only allow the account update from the transaction, not the SSTORE
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_kv_update_limit(1); // Only 1 KV update allowed
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_kv_update_limit(1); // Only 1 KV update allowed
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -554,7 +554,7 @@ fn test_block_tx_size_limit_default_unlimited() {
     let evm = evm_factory.create_evm(&mut state, evm_env);
 
     // Create block context with default limits (tx size should be u64::MAX)
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false);
+    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new());
     assert_eq!(block_ctx.block_tx_size_limit, u64::MAX, "Default tx size limit should be u64::MAX");
 
     // Create block executor
@@ -616,8 +616,8 @@ fn test_block_tx_size_limit_allows_multiple_transactions() {
     let tx_size = sample_tx.encode_2718_len() as u64;
 
     // Set limit to allow exactly 5 transactions
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false)
-        .with_tx_size_limit(tx_size * 5);
+    let block_ctx =
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_tx_size_limit(tx_size * 5);
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -671,7 +671,7 @@ fn test_block_tx_size_limit_exceeded_first_transaction() {
 
     // Set a very small tx size limit that won't fit even one transaction
     let block_ctx =
-        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false).with_tx_size_limit(10); // Very small limit
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_tx_size_limit(10); // Very small limit
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -732,8 +732,8 @@ fn test_block_tx_size_limit_exceeded_mid_block() {
     let tx_size = sample_tx.encode_2718_len() as u64;
 
     // Set limit to allow exactly 3 transactions
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false)
-        .with_tx_size_limit(tx_size * 3);
+    let block_ctx =
+        MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new()).with_tx_size_limit(tx_size * 3);
 
     // Create block executor
     let chain_spec = OpChainHardforks::base_mainnet();
@@ -803,7 +803,7 @@ fn test_block_tx_size_limit_with_varying_sizes() {
     let large_size = large_tx.encode_2718_len() as u64;
 
     // Set limit to allow 2 small + 1 large transaction
-    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new(), false)
+    let block_ctx = MegaBlockExecutionCtx::new(B256::ZERO, None, Bytes::new())
         .with_tx_size_limit(small_size * 2 + large_size);
 
     // Create block executor

--- a/crates/mega-evm/tests/oracle.rs
+++ b/crates/mega-evm/tests/oracle.rs
@@ -685,7 +685,6 @@ fn test_oracle_contract_deployed_on_mini_rex_activation() {
         B256::ZERO,
         Some(B256::ZERO), // Set a beacon block root
         Default::default(),
-        true, // first_mini_rex_block
     );
 
     // Try Base mainnet which should have the right hardfork configuration
@@ -727,8 +726,8 @@ fn test_oracle_contract_deployed_on_mini_rex_activation() {
 
     // Verify that calling deploy_oracle_contract again returns empty state
     // (proving the contract is already deployed)
-    use mega_evm::deploy_oracle_contract;
-    let result = deploy_oracle_contract(db_ref).expect("Should not error");
+    use mega_evm::ensure_oracle_contract_deployed;
+    let result = ensure_oracle_contract_deployed(db_ref).expect("Should not error");
     assert_eq!(
         result.len(),
         0,


### PR DESCRIPTION
## Summary
- Removed `is_first_mini_rex_block` parameter from `MegaBlockExecutionCtx::new()`
- Renamed `deploy_oracle_contract()` to `ensure_oracle_contract_deployed()` for clarity
- Updated all test files to remove the unnecessary parameter
- The oracle contract is now automatically deployed when entering MiniRex spec, regardless of block number

## Changes
- **crates/mega-evm/src/block.rs**: Removed `first_mini_rex_block` field and parameter
- **crates/mega-evm/src/system/oracle.rs**: Renamed function to better reflect its idempotent behavior
- **crates/mega-evm/tests/block_executor.rs**: Updated all test instantiations to use new 3-parameter constructor
- **crates/mega-evm/tests/oracle.rs**: Updated tests to use renamed function and new constructor

## Test plan
- All existing tests pass with updated API
- Clippy passes with no warnings
- Code formatted with rustfmt