### PR TITLE
feat: add bucket IDs reporting to transaction outcome

### DIFF
--- a/crates/mega-evm/src/context.rs
+++ b/crates/mega-evm/src/context.rs
@@ -22,6 +22,7 @@ use revm::{
     database::EmptyDB,
     Journal,
 };
+use salt::BucketId;
 use std::{cell::RefCell, rc::Rc};
 
 use crate::{
@@ -57,6 +58,17 @@ pub struct MegaContext<DB: Database, ExtEnvs: ExternalEnvs> {
     /* Internal state variables */
     /// Tracker for sensitive data access (block environment, beneficiary, etc.)
     pub volatile_data_tracker: Rc<RefCell<VolatileDataAccessTracker>>,
+}
+
+/// The additional transaction execution outcome.
+#[derive(Clone, Debug, Default)]
+pub struct AdditionalOutcome {
+    /// The data size usage in bytes.
+    pub data_size: u64,
+    /// The number of KV updates.
+    pub kv_updates: u64,
+    /// The bucket IDs used during transaction execution.
+    pub bucket_ids: Vec<BucketId>,
 }
 
 impl Default for MegaContext<EmptyDB, DefaultExternalEnvs> {
@@ -346,12 +358,26 @@ impl<DB: Database, ExtEnvs: ExternalEnvs> MegaContext<DB, ExtEnvs> {
         self.spec
     }
 
+    /// Gets the additional transaction execution outcome.
+    ///
+    /// # Returns
+    ///
+    /// Returns the additional transaction execution outcome.
+    pub fn additional_outcome(&self) -> AdditionalOutcome {
+        AdditionalOutcome {
+            data_size: self.additional_limit.borrow().data_size_tracker.current_size(),
+            kv_updates: self.additional_limit.borrow().kv_update_counter.current_count(),
+            bucket_ids: self.dynamic_gas_cost.borrow().get_bucket_ids(),
+        }
+    }
+
     /// Gets the current total data size generated from transaction execution.
     ///
     /// # Returns
     ///
     /// Returns the current total data size in bytes generated so far. The data size is reset at the
     /// beginning of each transaction.
+    #[deprecated(note = "Use `additional_outcome` instead")]
     pub fn generated_data_size(&self) -> u64 {
         self.additional_limit.borrow().data_size_tracker.current_size()
     }
@@ -362,6 +388,7 @@ impl<DB: Database, ExtEnvs: ExternalEnvs> MegaContext<DB, ExtEnvs> {
     ///
     /// Returns the current total number of KV operations performed so far. The count is reset at
     /// the beginning of each transaction.
+    #[deprecated(note = "Use `additional_outcome` instead")]
     pub fn kv_update_count(&self) -> u64 {
         self.additional_limit.borrow().kv_update_counter.current_count()
     }

--- a/crates/mega-evm/src/gas.rs
+++ b/crates/mega-evm/src/gas.rs
@@ -30,6 +30,11 @@ impl<SaltEnvImpl: SaltEnv> DynamicGasCost<SaltEnvImpl> {
         self.parent_block = parent_block;
     }
 
+    /// Gets the bucket IDs used during transaction execution.
+    pub fn get_bucket_ids(&self) -> Vec<BucketId> {
+        self.bucket_cost_mulitipers.keys().copied().collect()
+    }
+
     /// Calculates the gas cost for setting a storage slot to a non-zero value. This overrides the
     /// [`SSTORE_SET`](revm::interpreter::gas::SSTORE_SET) gas cost in the original EVM.
     pub fn sstore_set_gas(

--- a/crates/mega-evm/tests/additional_limit.rs
+++ b/crates/mega-evm/tests/additional_limit.rs
@@ -53,7 +53,8 @@ fn transact(
     let r = alloy_evm::Evm::transact_raw(&mut evm, tx)?;
 
     let ctx = evm.ctx_ref();
-    Ok((r, ctx.generated_data_size(), ctx.kv_update_count()))
+    let additional_outcome = ctx.additional_outcome();
+    Ok((r, additional_outcome.data_size, additional_outcome.kv_updates))
 }
 
 /// Checks if the execution result indicates that the data limit was exceeded.
@@ -964,8 +965,8 @@ fn test_limits_reset_across_multiple_transactions() {
     let mut mega_tx1 = MegaTransaction::new(tx1);
     mega_tx1.enveloped_tx = Some(Bytes::new());
     let res1 = alloy_evm::Evm::transact_raw(&mut evm, mega_tx1).unwrap();
-    let data_size_after_tx1 = evm.ctx_ref().generated_data_size();
-    let kv_updates_after_tx1 = evm.ctx_ref().kv_update_count();
+    let data_size_after_tx1 = evm.ctx_ref().additional_outcome().data_size;
+    let kv_updates_after_tx1 = evm.ctx_ref().additional_outcome().kv_updates;
 
     // Verify first transaction generated some data and KV updates
     assert_eq!(data_size_after_tx1, BASE_TX_SIZE + ACCOUNT_INFO_WRITE_SIZE);
@@ -979,8 +980,8 @@ fn test_limits_reset_across_multiple_transactions() {
     let mut mega_tx2 = MegaTransaction::new(tx2);
     mega_tx2.enveloped_tx = Some(Bytes::new());
     let _ = alloy_evm::Evm::transact_raw(&mut evm, mega_tx2).unwrap();
-    let data_size_after_tx2 = evm.ctx_ref().generated_data_size();
-    let kv_updates_after_tx2 = evm.ctx_ref().kv_update_count();
+    let data_size_after_tx2 = evm.ctx_ref().additional_outcome().data_size;
+    let kv_updates_after_tx2 = evm.ctx_ref().additional_outcome().kv_updates;
 
     // Verify counters reset and show only second transaction's data
     // Without reset, these would be 2x the single transaction values


### PR DESCRIPTION
## Summary
- Add `AdditionalOutcome` struct to consolidate transaction execution metrics
- Add `get_bucket_ids()` method to retrieve bucket IDs used during execution
- Deprecate `generated_data_size()` and `kv_update_count()` in favor of `additional_outcome()`
- Update tests to use the new `additional_outcome()` API

## Changes
- Added `AdditionalOutcome` struct with `data_size`, `kv_updates`, and `bucket_ids` fields
- Implemented `additional_outcome()` method in `MegaContext` to return all transaction metrics
- Added `get_bucket_ids()` method in `DynamicGasCost` to extract bucket IDs from the gas cost multipliers
- Deprecated existing individual metric getters in favor of unified API
- Updated test code to use new API