### PR TITLE
Add TxDASize trait and block DA size limit enforcement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2185,6 +2185,7 @@ dependencies = [
  "mega-evm",
  "once_cell",
  "op-alloy-consensus",
+ "op-alloy-flz",
  "op-revm",
  "revm",
  "revm-inspectors",
@@ -2383,6 +2384,12 @@ dependencies = [
  "derive_more",
  "thiserror",
 ]
+
+[[package]]
+name = "op-alloy-flz"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a79f352fc3893dcd670172e615afef993a41798a1d3fc0db88a3e60ef2e70ecc"
 
 [[package]]
 name = "op-revm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,6 +178,7 @@ alloy-rpc-types-trace = { version = "1.0.22" }
 alloy-serde = { version = "1.0.23", default-features = false }
 alloy-sol-types = { version = "1.0.23" }
 op-alloy-consensus = { version = "0.18.12", default-features = false }
+op-alloy-flz = { version = "0.13.1" }
 
 # misc
 auto_impl = "1.3"

--- a/crates/mega-evm/Cargo.toml
+++ b/crates/mega-evm/Cargo.toml
@@ -21,6 +21,7 @@ alloy-op-hardforks.workspace = true
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 op-alloy-consensus.workspace = true
+op-alloy-flz.workspace = true
 
 # megaeth
 salt.workspace = true


### PR DESCRIPTION
## Summary
- Add `TxDASize` trait for estimating transaction data availability size
- Implement `TxDASize` for `MegaTxEnvelope` and `Recovered<MegaTxEnvelope>`
- Add `block_da_size_limit` field to `MegaBlockExecutionCtx` with default value of `u64::MAX`
- Track `block_da_size_used` in `MegaBlockExecutor`
- Enforce DA size limit during transaction execution
- Add `DataAvailabilitySizeLimit` error variant to `MegaBlockLimitExceededError`
- Update trait bounds to require `TxDASize` for transaction types

## Changes
### New Trait: `TxDASize`
- Provides `estimated_da_size()` method with default implementation using `op_alloy_flz::tx_estimated_size_fjord_bytes`
- Default implementation includes documentation about caching inefficiency

### Block Execution Context
- Added `block_da_size_limit: u64` field (defaults to `u64::MAX`)
- Added `with_da_size_limit()` builder method for customization
- Added documentation clarifying the difference between `block_tx_size_limit` (uncompressed) and `block_da_size_limit` (DA compressed)

### Block Executor
- Track `block_da_size_used` during transaction execution
- Validate DA size before executing each transaction
- Include `da_size` in `MegaTransactionExecutionOutcome`
- Increment `block_da_size_used` when committing transaction outcomes

### Error Handling
- New `DataAvailabilitySizeLimit` variant in `MegaBlockLimitExceededError` with block_used, tx_used, and limit fields

## Test Plan
- All existing tests pass
- Compilation succeeds with no warnings
- Code formatted with `cargo fmt`