### PR TITLE
fix: mark oracle contract account as read in ensure_oracle_contract_deployed

### DIFF
--- a/crates/mega-evm/src/system/oracle.rs
+++ b/crates/mega-evm/src/system/oracle.rs
@@ -180,14 +180,18 @@ mod tests {
 
         let mut state = State::builder().with_database(&mut db).build();
 
-        // Deploy should return empty state (no changes needed)
+        // Deploy should return state with the account marked as read
         let result =
             ensure_oracle_contract_deployed(&mut state).expect("Deployment should succeed");
         assert_eq!(
             result.len(),
-            0,
-            "Deployment should return empty state when contract is already correctly deployed"
+            1,
+            "Deployment should return state with account marked as read when contract is already correctly deployed"
         );
+
+        // Verify the account is in the result
+        let account = result.get(&ORACLE_CONTRACT_ADDRESS).expect("Account should exist");
+        assert_eq!(account.info.code_hash, ORACLE_CONTRACT_CODE_HASH, "Code hash should match");
     }
 
     #[test]

--- a/crates/mega-evm/tests/oracle.rs
+++ b/crates/mega-evm/tests/oracle.rs
@@ -724,14 +724,14 @@ fn test_oracle_contract_deployed_on_mini_rex_activation() {
         "Deployed code should match original code"
     );
 
-    // Verify that calling deploy_oracle_contract again returns empty state
+    // Verify that calling deploy_oracle_contract again returns state with account marked as read
     // (proving the contract is already deployed)
     use mega_evm::ensure_oracle_contract_deployed;
     let result = ensure_oracle_contract_deployed(db_ref).expect("Should not error");
     assert_eq!(
         result.len(),
-        0,
-        "Oracle should already be deployed, so deploy_oracle_contract should return empty state"
+        1,
+        "Oracle should already be deployed, so deploy_oracle_contract should return state with account marked as read"
     );
 }
 


### PR DESCRIPTION
## Summary
- Mark the oracle contract account as read when it's already deployed, rather than returning an empty EvmState
- This ensures the account is properly tracked in the EVM state even when no updates are needed

## Changes
- Import `Account` type from `revm::state`
- Return an `EvmState` containing the oracle account marked as read when the contract is already deployed
- Prevents potential state tracking issues by ensuring all accessed accounts are recorded

## Test plan
- Existing tests should pass
- The change ensures proper state tracking for system contract calls