### PR TITLE
fix: add no_std support to mega-evm

### DIFF
--- a/crates/mega-evm/src/block/executor.rs
+++ b/crates/mega-evm/src/block/executor.rs
@@ -1,7 +1,5 @@
-use std::{borrow::Cow, collections::BTreeMap};
-
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap};
 use alloy_consensus::{Eip658Value, Header, Transaction, TxReceipt};
 use alloy_eips::{Encodable2718, Typed2718};
 pub use alloy_evm::block::CommitChanges;
@@ -23,6 +21,8 @@ use revm::{
     context::result::ExecutionResult, database::State, handler::EvmTr, DatabaseCommit, Inspector,
 };
 use salt::BucketId;
+#[cfg(feature = "std")]
+use std::{borrow::Cow, collections::BTreeMap};
 
 use crate::{
     ensure_high_precision_timestamp_oracle_contract_deployed, ensure_oracle_contract_deployed,

--- a/crates/mega-evm/src/evm/context.rs
+++ b/crates/mega-evm/src/evm/context.rs
@@ -23,7 +23,13 @@ use revm::{
     Journal,
 };
 use salt::BucketId;
-use std::{cell::RefCell, rc::Rc};
+
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
+use std::rc::Rc;
+
+use core::cell::RefCell;
 
 use crate::{
     constants, AdditionalLimit, DefaultExternalEnvs, DynamicGasCost, ExternalEnvs, MegaSpecId,

--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -122,7 +122,7 @@ where
         + From<MegaTransactionError>
         + FromStringError
         + IsTxError
-        + std::fmt::Debug,
+        + core::fmt::Debug,
     FRAME: FrameTr<FrameResult = FrameResult, FrameInit = FrameInit>,
 {
     type Evm = EVM;
@@ -373,7 +373,7 @@ where
         + From<MegaTransactionError>
         + FromStringError
         + IsTxError
-        + std::fmt::Debug,
+        + core::fmt::Debug,
 {
     type IT = EthInterpreter;
 

--- a/crates/mega-evm/src/evm/host.rs
+++ b/crates/mega-evm/src/evm/host.rs
@@ -1,4 +1,8 @@
 use core::cell::RefCell;
+
+#[cfg(not(feature = "std"))]
+use alloc::rc::Rc;
+#[cfg(feature = "std")]
 use std::rc::Rc;
 
 use crate::{

--- a/crates/mega-evm/src/evm/spec.rs
+++ b/crates/mega-evm/src/evm/spec.rs
@@ -1,11 +1,13 @@
 //! Definitions of the `MegaETH` EVM versions (`SpecId`).
 
 use clap::ValueEnum;
-use core::str::FromStr;
+use core::{
+    fmt::{self, Display},
+    str::FromStr,
+};
 pub use op_revm::OpSpecId;
 pub use revm::primitives::hardfork::{SpecId as EthSpecId, UnknownHardfork};
 use serde::{Deserialize, Serialize};
-use std::fmt::{self, Display};
 
 /// `MegaETH` spec id, defining different versions of the `MegaETH` EVM.
 ///

--- a/crates/mega-evm/src/external/gas.rs
+++ b/crates/mega-evm/src/external/gas.rs
@@ -1,5 +1,5 @@
 use core::fmt::Debug;
-use std::collections::hash_map::Entry;
+use revm::primitives::hash_map::Entry;
 
 use alloy_primitives::{Address, BlockNumber, B256, U256};
 use revm::{context::BlockEnv, primitives::HashMap};


### PR DESCRIPTION
## Summary
- Add full no_std support to mega-evm crate
- Replace std imports with core/alloc equivalents
- Remove unnecessary Send + Sync trait bounds
- Use Rc<RefCell<...>> instead of Arc<RwLock<...>> for DefaultExternalEnvs

## Changes
1. **Updated imports to support no_std**:
   - `std::fmt` → `core::fmt` 
   - `std::rc::Rc` → conditional import (`alloc::rc::Rc` for no_std)
   - `std::collections` → conditional import (`alloc::collections` for no_std)
   - `std::borrow::Cow` → conditional import (`alloc::borrow::Cow` for no_std)

2. **Removed Send + Sync bounds from traits**:
   - `ExternalEnvs`, `SaltEnv`, and `OracleEnv` traits no longer require Send + Sync
   - This enables use of single-threaded types in no_std environments

3. **Simplified DefaultExternalEnvs implementation**:
   - Changed from `Arc<RwLock<HashMap<...>>>` to `Rc<RefCell<HashMap<...>>>`
   - Updated access patterns from `.read()`/`.write()` to `.borrow()`/`.borrow_mut()`
   - No external dependencies needed for no_std builds

## Testing
- ✅ `cargo build --no-default-features` passes without warnings
- ✅ `cargo clippy --no-default-features` passes
- ✅ `cargo build` with std still works
- ✅ All unit tests pass