### PR TITLE
feat: introduce REX hardfork and unify opcode implementations

### DIFF
--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -351,6 +351,7 @@ impl BlockLimits {
         match *evm_env.spec_id() {
             MegaSpecId::EQUIVALENCE => Self::no_limits().fit_equivalence(),
             MegaSpecId::MINI_REX => Self::no_limits().fit_mini_rex(),
+            MegaSpecId::REX => Self::no_limits().fit_rex(),
         }
         .with_block_gas_limit(evm_env.block_env.gas_limit)
     }
@@ -379,6 +380,12 @@ impl BlockLimits {
             block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,
             ..self
         }
+    }
+
+    /// Fits the block limits to the rex spec. Overrides those limits with the
+    /// `MegaSpecId::REX` spec limits.
+    pub fn fit_rex(self) -> Self {
+        self.fit_mini_rex()
     }
 }
 

--- a/crates/mega-evm/src/evm/limit.rs
+++ b/crates/mega-evm/src/evm/limit.rs
@@ -18,6 +18,7 @@ impl EvmTxRuntimeLimits {
         match spec {
             MegaSpecId::EQUIVALENCE => Self::equivalence(),
             MegaSpecId::MINI_REX => Self::mini_rex(),
+            MegaSpecId::REX => Self::rex(),
         }
     }
 
@@ -46,6 +47,11 @@ impl EvmTxRuntimeLimits {
             tx_kv_updates_limit: crate::constants::mini_rex::TX_KV_UPDATE_LIMIT,
             tx_compute_gas_limit: crate::constants::mini_rex::TX_COMPUTE_GAS_LIMIT,
         }
+    }
+
+    /// Limits for the `REX` spec.
+    pub fn rex() -> Self {
+        Self::mini_rex()
     }
 }
 

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -37,6 +37,7 @@ impl MegaPrecompiles {
         let inner = match spec {
             MegaSpecId::EQUIVALENCE => op_revm::precompiles::isthmus(),
             MegaSpecId::MINI_REX => mini_rex(),
+            MegaSpecId::REX => rex(),
         };
 
         Self { inner: EthPrecompiles { precompiles: inner, spec: spec.into_eth_spec() }, spec }
@@ -51,6 +52,11 @@ impl MegaPrecompiles {
         // Custom gas costs will be applied in the run() method
         self.inner.precompiles
     }
+}
+
+/// Precompiles for the `REX` spec.
+pub fn rex() -> &'static Precompiles {
+    mini_rex()
 }
 
 /// Precompiles for the `MINI_REX` spec.

--- a/crates/mega-evm/src/evm/spec.rs
+++ b/crates/mega-evm/src/evm/spec.rs
@@ -17,6 +17,7 @@ use serde::{Deserialize, Serialize};
 /// corresponding relations are as follows:
 /// - [`SpecId::EQUIVALENCE`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::MINI_REX`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
+/// - [`SpecId::REX`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 #[repr(u8)]
 #[derive(
     Clone,
@@ -33,6 +34,7 @@ use serde::{Deserialize, Serialize};
     ValueEnum,
 )]
 #[allow(non_camel_case_types, clippy::upper_case_acronyms, missing_docs)]
+#[non_exhaustive]
 pub enum MegaSpecId {
     /// The EVM version when no `MegaETH` harfork is enabled. The behavior of the EVM
     /// should be equivalent to the [`OpSpecId::ISTHMUS`] of the Optimism EVM.
@@ -42,6 +44,9 @@ pub enum MegaSpecId {
     /// The EVM version for the *Mini-Rex* hardfork of `MegaETH`.
     #[value(name = "MiniRex")]
     MINI_REX,
+    /// The EVM version for the *Rex* hardfork of `MegaETH`.
+    #[value(name = "Rex")]
+    REX,
 }
 
 /// String identifiers for `MegaETH` EVM versions.
@@ -51,6 +56,8 @@ pub mod name {
     pub const EQUIVALENCE: &str = "Equivalence";
     /// The string identifier for the *Mini-Rex* version of the `MegaETH` EVM.
     pub const MINI_REX: &str = "MiniRex";
+    /// The string identifier for the *Rex* version of the `MegaETH` EVM.
+    pub const REX: &str = "Rex";
 }
 
 impl MegaSpecId {
@@ -62,7 +69,7 @@ impl MegaSpecId {
     /// Converts the [`SpecId`] into its corresponding [`OpSpecId`].
     pub const fn into_op_spec(self) -> OpSpecId {
         match self {
-            Self::MINI_REX | Self::EQUIVALENCE => OpSpecId::ISTHMUS,
+            Self::MINI_REX | Self::EQUIVALENCE | Self::REX => OpSpecId::ISTHMUS,
         }
     }
 
@@ -81,6 +88,7 @@ impl From<MegaSpecId> for &'static str {
         match spec_id {
             MegaSpecId::EQUIVALENCE => name::EQUIVALENCE,
             MegaSpecId::MINI_REX => name::MINI_REX,
+            MegaSpecId::REX => name::REX,
         }
     }
 }
@@ -93,6 +101,7 @@ impl FromStr for MegaSpecId {
         match s {
             name::EQUIVALENCE => Ok(Self::EQUIVALENCE),
             name::MINI_REX => Ok(Self::MINI_REX),
+            name::REX => Ok(Self::REX),
             _ => Err(UnknownHardfork),
         }
     }


### PR DESCRIPTION
## Summary

This PR introduces the **REX hardfork specification** and unifies the duplicate opcode implementations between MiniRex and Rex, reducing code duplication by 535 lines while maintaining functional equivalence.

## What is REX?

REX is a new hardfork that fixes bugs in MiniRex:
- **Bug Fix**: CALLCODE, DELEGATECALL, and STATICCALL now correctly use the 98/100 gas forwarding rule (they incorrectly used 63/64 in MiniRex)
- **Compatibility**: All other opcodes remain identical to MiniRex

## Key Changes

### 1. REX Hardfork Specification
- Added `MegaSpecId::REX` enum variant
- REX inherits MiniRex instruction table and overrides only 3 opcodes
- Fixes gas forwarding for CALLCODE, DELEGATECALL, STATICCALL to use 98/100 rule

### 2. Unified Opcode Implementations
**Removed duplicate implementations** of:
- LOG0-LOG4 opcodes
- SSTORE opcode  
- CREATE/CREATE2 opcodes
- CALL opcode

**Architecture**:
- MiniRex uses base implementations from `additional_limit_ext` and `forward_gas_ext`
- Rex inherits MiniRex table and overrides 3 call-like opcodes with correct gas forwarding
- Layered approach: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext` → revm

### 3. Performance Optimization
- `JournalInspectTr::inspect_storage` now returns `&EvmStorageSlot` instead of cloning
- Eliminates unnecessary allocations in SSTORE hot path
- Maintains correct gas accounting and warmth tracking

## Code Quality

**Before**: 1,400+ lines in instructions.rs with significant duplication  
**After**: 1,300 lines with shared implementations  
**Reduction**: 535 lines removed, 257 lines added (net -278 lines, -20%)

## Functional Equivalence

All opcode implementations are functionally equivalent to the original code:
- ✅ Identical gas costs (compute + storage + log)
- ✅ Same execution semantics and error handling
- ✅ Correct account/storage warmth tracking
- ✅ Preserved journal revert behavior on OOG/errors
- ✅ Data/KV limit enforcement unchanged

Verified through detailed analysis of execution flows, gas charging order, and corner cases (multiple SSTORE to same slot, insufficient gas scenarios, etc.).

## Migration Path

- **MiniRex**: No changes to behavior, uses unified implementations
- **REX**: New hardfork with fixes, opt-in when ready to deploy
- **Equivalence**: Existing code remains compatible, same gas costs

## Files Changed

- `crates/mega-evm/src/evm/spec.rs`: Add REX hardfork enum
- `crates/mega-evm/src/evm/instructions.rs`: Unify implementations (-535 lines)
- `crates/mega-evm/src/evm/limit.rs`: Add REX to limit handling
- `crates/mega-evm/src/evm/precompiles.rs`: Add REX to precompile handling
- `crates/mega-evm/src/block/limit.rs`: Add REX to block limit handling