### PR TITLE
refactor: add helper methods to retrieve accessed bucket IDs and block hashes

### DIFF
--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -28,7 +28,11 @@ mod limit;
 mod precompiles;
 mod result;
 mod spec;
+mod state;
 
+use std::collections::BTreeMap;
+
+use alloy_primitives::B256;
 pub use context::*;
 pub use execution::*;
 pub use factory::*;
@@ -39,11 +43,13 @@ pub use interfaces::*;
 pub use limit::*;
 pub use precompiles::*;
 pub use result::*;
+use salt::BucketId;
 pub use spec::*;
+pub use state::*;
 
 use alloy_evm::{precompiles::PrecompilesMap, Database};
 use revm::{
-    context::{result::ResultAndState, BlockEnv},
+    context::{result::ResultAndState, BlockEnv, ContextTr},
     handler::{EthFrame, EvmTr},
     inspector::NoOpInspector,
     interpreter::interpreter::EthInterpreter,
@@ -268,5 +274,25 @@ where
             kv_updates,
             compute_gas_used: compute_gas,
         })
+    }
+
+    /// Get the bucket IDs used during transaction execution.
+    ///
+    /// # Returns
+    ///
+    /// Returns the bucket IDs used during transaction execution.
+    pub fn get_accessed_bucket_ids(&self) -> Vec<BucketId> {
+        self.ctx_ref().dynamic_storage_gas_cost.borrow().get_bucket_ids()
+    }
+}
+
+impl<DB: Database + BlockHashes, INSP, ExtEnvs: ExternalEnvs> MegaEvm<DB, INSP, ExtEnvs> {
+    /// Get the block hashes used during transaction execution.
+    ///
+    /// # Returns
+    ///
+    /// Returns the block hashes used during transaction execution.
+    pub fn get_accessed_block_hashes(&self) -> BTreeMap<u64, B256> {
+        self.db_ref().get_accessed_block_hashes()
     }
 }

--- a/crates/mega-evm/src/evm/state.rs
+++ b/crates/mega-evm/src/evm/state.rs
@@ -1,0 +1,18 @@
+use std::collections::BTreeMap;
+
+use alloy_primitives::B256;
+use auto_impl::auto_impl;
+use revm::{database::State, Database};
+
+/// A helper trait to get the block hashes used during transaction execution.
+#[auto_impl(&, &mut, Box, Rc, Arc)]
+pub trait BlockHashes {
+    /// Get the block hashes used during transaction execution.
+    fn get_accessed_block_hashes(&self) -> BTreeMap<u64, B256>;
+}
+
+impl<DB: Database> BlockHashes for State<DB> {
+    fn get_accessed_block_hashes(&self) -> BTreeMap<u64, B256> {
+        self.block_hashes.clone()
+    }
+}


### PR DESCRIPTION
## Summary
- Add `BlockHashes` trait to abstract block hash retrieval from database state
- Implement `get_accessed_bucket_ids()` method on `MegaEvm` to retrieve bucket IDs accessed during transaction execution
- Implement `get_accessed_block_hashes()` method on `MegaEvm` to retrieve block hashes accessed during transaction execution

These helper methods enable retrieving accessed bucket IDs and block hashes before the block executor is consumed in the `finish()` method.

## Changes
- Created new `state.rs` module with `BlockHashes` trait
- Added `get_accessed_bucket_ids()` to retrieve bucket IDs from dynamic storage gas cost tracking
- Added `get_accessed_block_hashes()` for databases implementing `BlockHashes` trait
- Properly organized imports and module structure