### PR TITLE
feat: add support for customizable precompiles

### DIFF
--- a/crates/mega-evm/src/block/executor.rs
+++ b/crates/mega-evm/src/block/executor.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(not(feature = "std"))]
-use alloc::{borrow::Cow, boxed::Box, collections::BTreeMap};
+use alloc as std;
+use std::{borrow::Cow, boxed::Box, collections::BTreeMap, vec::Vec};
+
 use alloy_consensus::{Eip658Value, Header, Transaction, TxReceipt};
 use alloy_eips::{Encodable2718, Typed2718};
 pub use alloy_evm::block::CommitChanges;
@@ -23,8 +23,6 @@ use revm::{
     context::result::ExecutionResult, database::State, handler::EvmTr, DatabaseCommit, Inspector,
 };
 use salt::BucketId;
-#[cfg(feature = "std")]
-use std::{borrow::Cow, collections::BTreeMap};
 
 use crate::{
     ensure_high_precision_timestamp_oracle_contract_deployed, ensure_oracle_contract_deployed,

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -180,7 +180,9 @@
 //! - [Block and Transaction Limits Documentation](../../../docs/BLOCK_AND_TX_LIMITS.md)
 
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
+use alloc as std;
+use std::boxed::Box;
+
 use alloy_consensus::Transaction;
 use alloy_evm::{
     block::{BlockExecutionError, BlockValidationError},

--- a/crates/mega-evm/src/evm/context.rs
+++ b/crates/mega-evm/src/evm/context.rs
@@ -12,8 +12,13 @@
 //! - **Block Environment Access Tracking**: Monitors which block environment data is accessed
 //! - **Spec Management**: Handles different `MegaETH` specification versions
 
+#[cfg(not(feature = "std"))]
+use alloc as std;
+use std::{rc::Rc, vec::Vec};
+
 use alloy_evm::Database;
 use alloy_primitives::Address;
+use core::cell::RefCell;
 use delegate::delegate;
 use op_revm::{DefaultOp, L1BlockInfo, OpContext, OpSpecId};
 use revm::{
@@ -23,15 +28,6 @@ use revm::{
     Journal,
 };
 use salt::BucketId;
-
-#[cfg(not(feature = "std"))]
-use alloc::rc::Rc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use std::rc::Rc;
-
-use core::cell::RefCell;
 
 use crate::{
     constants, AdditionalLimit, DefaultExternalEnvs, DynamicGasCost, EvmTxRuntimeLimits,

--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "std"))]
-use crate::alloc::string::ToString;
+use alloc as std;
+use std::string::ToString;
 
 use alloy_evm::{precompiles::PrecompilesMap, Database};
 use alloy_primitives::TxKind;

--- a/crates/mega-evm/src/evm/factory.rs
+++ b/crates/mega-evm/src/evm/factory.rs
@@ -141,8 +141,7 @@ where
         MegaEvm::new(ctx).with_dyn_precompiles(
             self.dyn_precompiles_builder
                 .as_ref()
-                .map(|builder| builder(spec_id))
-                .unwrap_or_default(),
+                .map_or_else(Default::default, |builder| builder(spec_id)),
         )
     }
 

--- a/crates/mega-evm/src/evm/host.rs
+++ b/crates/mega-evm/src/evm/host.rs
@@ -1,8 +1,7 @@
 use core::cell::RefCell;
 
 #[cfg(not(feature = "std"))]
-use alloc::rc::Rc;
-#[cfg(feature = "std")]
+use alloc as std;
 use std::rc::Rc;
 
 use crate::{

--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -31,11 +31,8 @@ mod spec;
 mod state;
 
 #[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-#[cfg(feature = "std")]
-use std::collections::BTreeMap;
+use alloc as std;
+use std::{collections::BTreeMap, vec::Vec};
 
 use alloy_primitives::{Address, B256};
 pub use context::*;
@@ -190,7 +187,7 @@ impl<DB: Database, INSP, ExtEnvs: ExternalEnvs> MegaEvm<DB, INSP, ExtEnvs> {
     /// # Returns
     ///
     /// A new `Evm` instance with the dynamic precompiles added.
-    pub fn with_dyn_precompiles(self, dyn_precompiles: HashMap<Address, DynPrecompile>) -> Self {
+    fn with_dyn_precompiles(self, dyn_precompiles: HashMap<Address, DynPrecompile>) -> Self {
         let mut precompiles = self.inner.precompiles;
         // Apply the dynamic precompiles to the precompiles map. If the precompile already exists,
         // it will be overridden with the dynamic precompile.

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -4,12 +4,8 @@
 //! gas cost overrides.
 
 #[cfg(not(feature = "std"))]
-use alloc::sync::Arc;
-#[cfg(feature = "std")]
-use std::sync::Arc;
-
-#[cfg(not(feature = "std"))]
-use alloc::string::String;
+use alloc as std;
+use std::{boxed::Box, string::String, sync::Arc};
 
 use crate::{ExternalEnvs, MegaContext, MegaSpecId};
 use alloy_evm::{
@@ -27,9 +23,6 @@ use revm::{
     precompile::Precompiles,
     primitives::{Address, HashMap},
 };
-
-#[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
 
 /// `MegaETH` precompile provider with custom gas cost overrides.
 #[derive(Debug, Clone)]

--- a/crates/mega-evm/src/evm/state.rs
+++ b/crates/mega-evm/src/evm/state.rs
@@ -1,6 +1,5 @@
 #[cfg(not(feature = "std"))]
-use alloc::collections::BTreeMap;
-#[cfg(feature = "std")]
+use alloc as std;
 use std::collections::BTreeMap;
 
 use alloy_primitives::B256;

--- a/crates/mega-evm/src/external/gas.rs
+++ b/crates/mega-evm/src/external/gas.rs
@@ -1,5 +1,7 @@
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc as std;
+use std::vec::Vec;
+
 use core::fmt::Debug;
 use revm::primitives::hash_map::Entry;
 

--- a/crates/mega-evm/src/external/mod.rs
+++ b/crates/mega-evm/src/external/mod.rs
@@ -3,11 +3,8 @@
 use core::{cell::RefCell, convert::Infallible, fmt::Debug};
 
 #[cfg(not(feature = "std"))]
-use alloc::boxed::Box;
-#[cfg(not(feature = "std"))]
-use alloc::{rc::Rc, sync::Arc};
-#[cfg(feature = "std")]
-use std::{rc::Rc, sync::Arc};
+use alloc as std;
+use std::{boxed::Box, rc::Rc, sync::Arc};
 
 use alloy_primitives::{BlockNumber, U256};
 use auto_impl::auto_impl;

--- a/crates/mega-evm/src/limit/data_size.rs
+++ b/crates/mega-evm/src/limit/data_size.rs
@@ -1,5 +1,7 @@
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc as std;
+use std::vec::Vec;
+
 use alloy_primitives::{Address, U256};
 use revm::{
     context::{transaction::AuthorizationTr, Transaction},

--- a/crates/mega-evm/src/limit/kv_update.rs
+++ b/crates/mega-evm/src/limit/kv_update.rs
@@ -1,5 +1,7 @@
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc as std;
+use std::vec::Vec;
+
 use alloy_primitives::{Address, U256};
 use revm::{
     context::{transaction::AuthorizationTr, Transaction},

--- a/crates/mega-evm/src/test_utils/bytes.rs
+++ b/crates/mega-evm/src/test_utils/bytes.rs
@@ -1,5 +1,6 @@
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc as std;
+use std::vec::Vec;
 
 /// Pads the bytes to the right with 0s to make it a multiple of the length.
 pub fn right_pad_bytes(bytes: impl AsRef<[u8]>, multiple_of: usize) -> Vec<u8> {

--- a/crates/mega-evm/src/test_utils/inspectors.rs
+++ b/crates/mega-evm/src/test_utils/inspectors.rs
@@ -1,11 +1,8 @@
 #[cfg(not(feature = "std"))]
-use alloc::rc::Rc;
-#[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
-use core::cell::RefCell;
-#[cfg(feature = "std")]
-use std::rc::Rc;
+use alloc as std;
+use std::{rc::Rc, vec::Vec};
 
+use core::cell::RefCell;
 use revm::{
     bytecode::OpCode,
     context::{ContextTr, JournalTr},

--- a/crates/mega-evm/src/test_utils/opcode_gen.rs
+++ b/crates/mega-evm/src/test_utils/opcode_gen.rs
@@ -1,7 +1,9 @@
 //! This module provides utility functions to generate EVM bytecode.
 
 #[cfg(not(feature = "std"))]
-use alloc::vec::Vec;
+use alloc as std;
+use std::vec::Vec;
+
 use alloy_primitives::{Address, Bytes, U256};
 use revm::bytecode::opcode::{
     DUP1, EQ, INVALID, JUMPDEST, JUMPI, MSTORE, PUSH0, RETURN, REVERT, SSTORE, STOP,


### PR DESCRIPTION
## Summary
- Added `DynPrecompilesBuilder` type to allow users to provide custom precompile implementations
- Added `with_dyn_precompiles_builder` method to `MegaEvmFactory` for configuration
- Added `with_dyn_precompiles` method to `MegaEvm` to apply dynamic precompiles
- Modified factory to pass dynamic precompiles to EVM instances during creation

## Changes
- **factory.rs**: Added optional `dyn_precompiles_builder` field and configuration method
- **mod.rs**: Added `with_dyn_precompiles` method to apply custom precompiles
- **precompiles.rs**: Added `DynPrecompilesBuilder` type alias for builder function