### PR TITLE
refactor: change Rex 160k gas from intrinsic to floor gas

### DIFF
--- a/crates/mega-evm/src/constants.rs
+++ b/crates/mega-evm/src/constants.rs
@@ -84,7 +84,7 @@ pub mod mini_rex {
 
 /// Constants for the `REX` spec.
 pub mod rex {
-    /// Additional storage gas cost added to transaction intrinsic gas for the `REX` spec.
-    /// This is charged on top of the base 21,000 intrinsic gas for all transactions.
-    pub const TX_INTRINSIC_STORAGE_GAS: u64 = 160_000;
+    /// The floor storage gas cost added to EIP-7623 floor gas for the `REX` spec.
+    /// This is charged on top of the current EIP-7623 floor gas for all transactions.
+    pub const TX_FLOOR_STORAGE_GAS: u64 = 160_000;
 }

--- a/crates/mega-evm/tests/rex/main.rs
+++ b/crates/mega-evm/tests/rex/main.rs
@@ -1,3 +1,3 @@
 //! Tests for Rex hardfork features.
 
-mod intrinsic_gas;
+mod floor_gas;


### PR DESCRIPTION
## Summary

Changes the Rex hardfork's 160,000 gas charge from an intrinsic gas cost to a floor gas cost. This aligns with EIP-7623 floor gas model where the gas acts as a minimum threshold rather than an additional base cost.

## Changes

- Renamed `TX_INTRINSIC_STORAGE_GAS` to `TX_FLOOR_STORAGE_GAS` in constants
- Changed implementation to add 160k to `floor_gas` instead of `initial_gas`
- Added validation to reject transactions when `floor_gas` exceeds gas limit
- Renamed test file from `intrinsic_gas.rs` to `floor_gas.rs`
- Updated all test cases and comments to reflect floor gas semantics

## Key Differences

**Before (Intrinsic Gas):**
- 160k was always added to transaction cost regardless of execution
- Simple transfer: 21k base + 160k = 181k gas used

**After (Floor Gas):**
- 160k is part of floor calculation: `max(initial_gas, floor_gas)`
- Simple transfer: still 181k gas used (floor is higher)
- Contract creation with high initial gas: floor doesn't add cost when initial > floor

## Testing

All existing tests updated and passing with new floor gas semantics.