### PR TITLE
chore: deprecate into_journaled_state and introduce into_parts method for MegaEvm

### DIFF
--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -262,7 +262,7 @@ impl<DB: Database, INSP, ExtEnvs: ExternalEnvs> MegaEvm<DB, INSP, ExtEnvs> {
     /// This is useful when you need to extract the final state after EVM execution
     /// and no longer need the EVM instance.
     #[inline]
-    #[deprecated(note = "Use `into_parts` instead")]
+    #[deprecated(note = "Use `into_inner` instead")]
     pub fn into_journaled_state(self) -> Journal<DB> {
         self.inner.ctx.inner.journaled_state
     }
@@ -272,6 +272,7 @@ impl<DB: Database, INSP, ExtEnvs: ExternalEnvs> MegaEvm<DB, INSP, ExtEnvs> {
     /// This method is typically used after EVM execution when you need to access
     /// the underlying EVM components and no longer require the `MegaEvm` wrapper.
     #[inline]
+    #[allow(clippy::type_complexity)]
     pub fn into_inner(
         self,
     ) -> revm::context::Evm<

--- a/crates/state-test/src/runner.rs
+++ b/crates/state-test/src/runner.rs
@@ -425,12 +425,12 @@ fn execute_single_test<'a>(ctx: TestExecutionContext<'a>) -> Result<(), TestErro
         let mut evm = MegaEvm::new(evm_context)
             .with_inspector(TracerEip3155::buffered(stderr()).without_summary());
         let res = evm.inspect_tx_commit(tx);
-        let db = evm.into_journaled_state().database;
+        let db = evm.into_inner().ctx.into_inner().journaled_state.database;
         (db, res)
     } else {
         let mut evm = MegaEvm::new(evm_context);
         let res = evm.transact_commit(tx);
-        let db = evm.into_journaled_state().database;
+        let db = evm.into_inner().ctx.into_inner().journaled_state.database;
         (db, res)
     };
     *ctx.elapsed.lock().unwrap() += timer.elapsed();
@@ -475,7 +475,7 @@ fn debug_failed_test<'a>(ctx: DebugContext<'a>) {
 
     let exec_result = evm.inspect_tx_commit(tx);
 
-    let state_after = evm.into_journaled_state().database;
+    let state_after = evm.into_inner().ctx.into_inner().journaled_state.database;
     prune_base_fee_vault_changes(state_after);
 
     println!("\nExecution result: {exec_result:#?}");


### PR DESCRIPTION
The `into_journaled_state` method is now deprecated in favor of the new `into_parts` method, which allows for consuming the `MegaEvm` instance and accessing the underlying EVM components directly. This change improves clarity and usability when working with the EVM after execution.