### PR TITLE
fix: use precision-preserving formula for 98/100 gas forwarding rule

### DIFF
--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -430,7 +430,8 @@ pub mod forward_gas_ext {
 
                         // Calculate the amount of gas that should be returned to the parent call
                         // under the 98/100 rule.
-                        let forwarded_gas_cap = parent_original_gas_left * 98 / 100;
+                        let forwarded_gas_cap =
+                            parent_original_gas_left - parent_original_gas_left * 2 / 100;
                         let capped_forwarded_gas = min(forwarded_gas, forwarded_gas_cap);
                         let gas_to_return = forwarded_gas - capped_forwarded_gas; // Safe from underflow
 
@@ -459,7 +460,8 @@ pub mod forward_gas_ext {
 
                         // Calculate the amount of gas that should be returned to the parent call
                         // under the 98/100 rule.
-                        let forwarded_gas_cap = parent_original_gas_left * 98 / 100;
+                        let forwarded_gas_cap =
+                            parent_original_gas_left - parent_original_gas_left * 2 / 100;
                         let capped_forwarded_gas = min(forwarded_gas, forwarded_gas_cap);
                         let gas_to_return = forwarded_gas - capped_forwarded_gas; // Safe from underflow
 


### PR DESCRIPTION
## Summary

Replace `parent_original_gas_left * 98 / 100` with `parent_original_gas_left - parent_original_gas_left * 2 / 100` to match v1.0.1 behavior and avoid integer division precision loss in the gas forwarding calculation.

## Problem

The current implementation uses `x * 98 / 100` to calculate the 98/100 gas forwarding cap, but this can produce different results than the v1.0.1 formula `x - (x * 2 / 100)` due to integer division truncation.

**Example with gas = 101:**
- Current (wrong): `101 * 98 / 100 = 9898 / 100 = 98`
- v1.0.1 (correct): `101 - (101 * 2 / 100) = 101 - 2 = 99`

This 1-gas difference can occur for various small gas amounts.

## Changes

- Updated gas forwarding calculation in `forward_gas_ext::call` wrapper for CALL-like opcodes
- Updated gas forwarding calculation in `forward_gas_ext::create` wrapper for CREATE-like opcodes
- Both now use the mathematically equivalent but precision-preserving formula

## Impact

- Restores bit-exact compatibility with mega-evm v1.0.1
- Affects all CALL, CALLCODE, DELEGATECALL, STATICCALL, CREATE, and CREATE2 opcodes
- Only impacts edge cases with specific gas amounts where integer division precision matters