### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2997,7 +2997,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evme"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5076,7 +5076,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-test"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ exclude = []
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
 [workspace.package]
-version = "1.1.0"
+version = "1.1.1"
 edition = "2021"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bump version from 1.1.0 to 1.1.1