### PR TITLE
refactor(mega-evm): add helper methods to MegaBlockLimitExceededError

### DIFF
--- a/crates/mega-evm/src/block/result.rs
+++ b/crates/mega-evm/src/block/result.rs
@@ -56,6 +56,26 @@ pub enum MegaTxLimitExceededError {
     },
 }
 
+impl MegaTxLimitExceededError {
+    /// The amount of the resource used by the current transaction.
+    pub fn usage(&self) -> u64 {
+        match self {
+            Self::TransactionGasLimit { tx_gas_limit, .. } => *tx_gas_limit,
+            Self::TransactionEncodeSizeLimit { tx_size, .. } => *tx_size,
+            Self::DataAvailabilitySizeLimit { da_size, .. } => *da_size,
+        }
+    }
+
+    /// The limit of the resource.
+    pub fn limit(&self) -> u64 {
+        match self {
+            Self::TransactionGasLimit { limit, .. } |
+            Self::TransactionEncodeSizeLimit { limit, .. } |
+            Self::DataAvailabilitySizeLimit { limit, .. } => *limit,
+        }
+    }
+}
+
 impl InvalidTxError for MegaTxLimitExceededError {
     fn is_nonce_too_low(&self) -> bool {
         false


### PR DESCRIPTION
## Summary
- Add `block_used()` accessor method to get total block resource usage
- Add `tx_used()` accessor method to get transaction resource usage
- Add `limit()` accessor method to get the resource limit

These helper methods extract common fields from all variants of `MegaBlockLimitExceededError`, making it easier to work with the error type programmatically.