### PR TITLE
fix: use tx_data_limit instead of tx_da_size_limit in block limits

### DIFF
--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -383,7 +383,7 @@ impl BlockLimits {
     pub fn fit_equivalence(self) -> Self {
         let tx_runtime_limits = EvmTxRuntimeLimits::equivalence();
         Self {
-            tx_da_size_limit: tx_runtime_limits.tx_data_size_limit,
+            tx_data_limit: tx_runtime_limits.tx_data_size_limit,
             tx_kv_update_limit: tx_runtime_limits.tx_kv_updates_limit,
             tx_compute_gas_limit: tx_runtime_limits.tx_compute_gas_limit,
             tx_state_growth_limit: tx_runtime_limits.tx_state_growth_limit,
@@ -396,7 +396,7 @@ impl BlockLimits {
     pub fn fit_mini_rex(self) -> Self {
         let tx_runtime_limits = EvmTxRuntimeLimits::mini_rex();
         Self {
-            tx_da_size_limit: tx_runtime_limits.tx_data_size_limit,
+            tx_data_limit: tx_runtime_limits.tx_data_size_limit,
             tx_kv_update_limit: tx_runtime_limits.tx_kv_updates_limit,
             tx_compute_gas_limit: tx_runtime_limits.tx_compute_gas_limit,
             tx_state_growth_limit: tx_runtime_limits.tx_state_growth_limit,
@@ -411,7 +411,7 @@ impl BlockLimits {
     pub fn fit_rex(self) -> Self {
         let tx_runtime_limits = EvmTxRuntimeLimits::rex();
         Self {
-            tx_da_size_limit: tx_runtime_limits.tx_data_size_limit,
+            tx_data_limit: tx_runtime_limits.tx_data_size_limit,
             tx_kv_update_limit: tx_runtime_limits.tx_kv_updates_limit,
             tx_compute_gas_limit: tx_runtime_limits.tx_compute_gas_limit,
             tx_state_growth_limit: tx_runtime_limits.tx_state_growth_limit,


### PR DESCRIPTION
## Summary
- Fix incorrect field mapping in `fit_equivalence()`, `fit_mini_rex()`, and `fit_rex()` methods
- `tx_runtime_limits.tx_data_size_limit` was incorrectly assigned to `tx_da_size_limit` instead of `tx_data_limit`