### PR TITLE
Revert "feat: access inner.sload() when sload() access oracle slot"

### DIFF
--- a/crates/mega-evm/src/evm/host.rs
+++ b/crates/mega-evm/src/evm/host.rs
@@ -89,9 +89,6 @@ impl<DB: Database, ExtEnvs: ExternalEnvTypes> Host for MegaContext<DB, ExtEnvs> 
     }
 
     fn sload(&mut self, address: Address, key: U256) -> Option<StateLoad<U256>> {
-        // ParallelEvm need record the `read_version` of the oracle slot, so we need to
-        // call `sload()` here to invoke `storage()` of `Database`.
-        let inner_value = self.inner.sload(address, key);
         if self.spec.is_enabled(MegaSpecId::MINI_REX) && address == ORACLE_CONTRACT_ADDRESS {
             // if the oracle env provides a value, return it. Otherwise, fallback to the inner
             // context.
@@ -99,7 +96,7 @@ impl<DB: Database, ExtEnvs: ExternalEnvTypes> Host for MegaContext<DB, ExtEnvs> 
                 return Some(StateLoad::new(value, true));
             }
         }
-        inner_value
+        self.inner.sload(address, key)
     }
 
     fn balance(&mut self, address: Address) -> Option<StateLoad<U256>> {


### PR DESCRIPTION
## Summary
- Reverts commit 36c44ff which added a call to `inner.sload()` before checking oracle slots
- The original change was intended to help ParallelEvm record `read_version` of oracle slots, but it introduces unintended side effect: 
  - The output EvmState will incorrectly include a storage slot of `ORACLE_CONTRACT` with zero value, which will mislead downstream softwares. 

This reverts commit 36c44ffac14a5f06079212ed45a572a57d1f3f75.