### PR TITLE
refactor: simplify block limit error messages

### DIFF
--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -818,7 +818,6 @@ impl BlockLimiter {
                 hash: tx_hash,
                 error: Box::new(MegaBlockLimitExceededError::TransactionDataLimit {
                     block_used: self.block_data_used,
-                    tx_used: 0,
                     limit: self.limits.block_txs_data_limit,
                 }),
             }));
@@ -830,7 +829,6 @@ impl BlockLimiter {
                 hash: tx_hash,
                 error: Box::new(MegaBlockLimitExceededError::KVUpdateLimit {
                     block_used: self.block_kv_updates_used,
-                    tx_used: 0,
                     limit: self.limits.block_kv_update_limit,
                 }),
             }));
@@ -842,7 +840,6 @@ impl BlockLimiter {
                 hash: tx_hash,
                 error: Box::new(MegaBlockLimitExceededError::ComputeGasLimit {
                     block_used: self.block_compute_gas_used,
-                    tx_used: 0,
                     limit: self.limits.block_compute_gas_limit,
                 }),
             }));
@@ -854,7 +851,6 @@ impl BlockLimiter {
                 hash: tx_hash,
                 error: Box::new(MegaBlockLimitExceededError::StateGrowthLimit {
                     block_used: self.block_state_growth_used,
-                    tx_used: 0,
                     limit: self.limits.block_state_growth_limit,
                 }),
             }));

--- a/crates/mega-evm/src/block/result.rs
+++ b/crates/mega-evm/src/block/result.rs
@@ -82,41 +82,33 @@ impl InvalidTxError for MegaTxLimitExceededError {
     }
 }
 
-/// Error type for block-level limit exceeded. These errors are only thrown after the transaction
-/// execution but before any changes are committed to the database.
+/// Error type for block-level limit exceeded. These errors are thrown when the block has already
+/// exceeded its limit (from a previous transaction) and no more transactions can be added.
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum MegaBlockLimitExceededError {
-    /// Block transactions data limit exceeded.
-    #[error(
-        "Block transactions data limit exceeded: block_used={block_used} + tx_used={tx_used} > limit={limit}"
-    )]
+    /// Block transactions data limit reached.
+    #[error("Block transactions data limit reached: block_used={block_used} >= limit={limit}")]
     TransactionDataLimit {
         /// Transaction data used by block so far
         block_used: u64,
-        /// Transaction data used by current transaction
-        tx_used: u64,
         /// Block transactions data limit
         limit: u64,
     },
 
-    /// Block KV update limit exceeded.
-    #[error("Block KV update limit exceeded: block_used={block_used} + tx_used={tx_used} > limit={limit}")]
+    /// Block KV update limit reached.
+    #[error("Block KV update limit reached: block_used={block_used} >= limit={limit}")]
     KVUpdateLimit {
         /// KV updates used by block so far
         block_used: u64,
-        /// KV updates used by current transaction
-        tx_used: u64,
         /// Block KV update limit
         limit: u64,
     },
 
-    /// Block compute gas limit exceeded.
-    #[error("Block compute gas limit exceeded: block_used={block_used} + tx_used={tx_used} > limit={limit}")]
+    /// Block compute gas limit reached.
+    #[error("Block compute gas limit reached: block_used={block_used} >= limit={limit}")]
     ComputeGasLimit {
         /// Compute gas used by block so far
         block_used: u64,
-        /// Compute gas used by current transaction
-        tx_used: u64,
         /// Block compute gas limit
         limit: u64,
     },
@@ -143,13 +135,11 @@ pub enum MegaBlockLimitExceededError {
         limit: u64,
     },
 
-    /// Block state growth limit exceeded.
-    #[error("Block state growth limit exceeded: block_used={block_used} + tx_used={tx_used} > limit={limit}")]
+    /// Block state growth limit reached.
+    #[error("Block state growth limit reached: block_used={block_used} >= limit={limit}")]
     StateGrowthLimit {
         /// State growth used by block so far
         block_used: u64,
-        /// State growth used by current transaction
-        tx_used: u64,
         /// Block state growth limit
         limit: u64,
     },
@@ -165,18 +155,6 @@ impl MegaBlockLimitExceededError {
             Self::TransactionEncodeSizeLimit { block_used, .. } |
             Self::DataAvailabilitySizeLimit { block_used, .. } |
             Self::StateGrowthLimit { block_used, .. } => *block_used,
-        }
-    }
-
-    /// The amount of the resource used by the current transaction.
-    pub fn tx_used(&self) -> u64 {
-        match self {
-            Self::TransactionDataLimit { tx_used, .. } |
-            Self::KVUpdateLimit { tx_used, .. } |
-            Self::ComputeGasLimit { tx_used, .. } |
-            Self::TransactionEncodeSizeLimit { tx_used, .. } |
-            Self::DataAvailabilitySizeLimit { tx_used, .. } |
-            Self::StateGrowthLimit { tx_used, .. } => *tx_used,
         }
     }
 


### PR DESCRIPTION
## Summary

Improve block limit error messages to accurately reflect the limit checking logic:

- **Post-execution limits** (data, KV, compute gas, state growth):
  - Remove `tx_used` field since it's always 0 when the error is thrown
  - Use "reached" with `>=` to reflect the actual check condition (`block_used >= limit`)
  - These errors occur when the block already exceeded limits from a previous transaction

- **Pre-execution limits** (encode size, DA size):
  - Keep `tx_used` field since the current transaction's size is relevant
  - Use "exceeded" with `+` and `>` since these check `block_used + tx_used > limit`

## Test plan
- [x] `cargo check` passes