### PR TITLE
docs: clarify max total gas limit is not EVM-limited

### DIFF
--- a/specs/MiniRex.md
+++ b/specs/MiniRex.md
@@ -131,6 +131,8 @@ MiniRex enforces the following resource limits.
 
 Other limits are left unlimited.
 
+**Note**: The max total gas limit for either a single transaction or a whole block is not limited by the EVM spec; it is a chain-configurable parameter.
+
 ### 2.7 Oracle Contract
 
 The oracle contract (as defined in [ORACLE_SERVICE.md](../docs/ORACLE_SERVICE.md)) will be deployed as pre-execution state changes in the first block of MiniRex hardfork at address `0x6342000000000000000000000000000000000001`.

--- a/specs/Rex.md
+++ b/specs/Rex.md
@@ -129,6 +129,8 @@ Rex unifies the behaviors of all CALL-like opcodes.
 - Transaction compute gas limit: 1B → 200M (5× decrease)
 - Block compute gas limit: Unlimited (unchanged)
 
+**Note**: The max total gas limit (storage + compute gas) is unlimited.
+
 #### 2.4.3 State Growth Limits
 
 | Spec        | Transaction Limit    | Block Limit          |
@@ -165,6 +167,7 @@ Rex unifies the behaviors of all CALL-like opcodes.
 - All limits checked during/after execution
 - KV updates: all storage writes (including updates to existing slots)
 - State growth: only new entries (0→non-0 writes, new accounts, new code)
+- The max total gas limit for either a single transaction or a whole block is not limited by the EVM spec; it is a chain-configurable parameter.
 
 ## 3. Specification Mapping
 


### PR DESCRIPTION
## Summary
- Add note in MiniRex.md clarifying that the max total gas limit for either a single transaction or a whole block is not limited by the EVM spec
- Add note in Rex.md clarifying that the max total gas limit (storage + compute gas) is unlimited
- Add note in Rex.md summary section for consistency with MiniRex