### PR TITLE
feat: add post_execution_update_raw method for resource usage tracking

### DIFF
--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -971,7 +971,7 @@ impl BlockLimiter {
     }
 
     /// Returns true if any block-level limit has been reached or exceeded.
-    pub fn is_block_limit_exceeded(&self) -> bool {
+    pub fn is_block_limit_reached(&self) -> bool {
         self.block_gas_used >= self.limits.block_gas_limit ||
             self.block_tx_size_used >= self.limits.block_txs_encode_size_limit ||
             self.block_da_size_used >= self.limits.block_da_size_limit ||


### PR DESCRIPTION

  ## Summary

  - Added `BlockLimiter::post_execution_update_raw(...)` to update block usage counters from precomputed values without requiring a `BlockMegaTransactionOutcome`.
  - Added `BlockLimiter::is_block_limit_exceeded()` for a single source of truth on block‑limit checks.
  - Refactored `post_execution_check` to delegate to `post_execution_update_raw`, keeping the accounting logic centralized.

  ## Parallel EVM usage (mega-reth)

  - In `parallel_evm/storages/workspace.rs`, `try_use_limit` now calls `limit_state.post_execution_update_raw(...)` and then `limit_state.is_block_limit_exceeded()` to mark the block full.
  - The local counter updates and `block_limit_exceeded` helper are removed, so block limit logic is fully governed by mega‑evm.