### PR TITLE
feat: introduce Rex2 hardfork with SELFDESTRUCT re-enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ This repository contains a customized version of the revm EVM implementation spe
 
 This codebase distinguishes between two related concepts:
 
-- **Spec (`MegaSpecId`)**: Defines EVM behavior - what the EVM does. Values: `EQUIVALENCE`, `MINI_REX`, `REX`
-- **Hardfork (`MegaHardfork`)**: Defines network upgrade events - when specs are activated. Values: `MiniRex`, `MiniRex1`, `MiniRex2`, `Rex`
+- **Spec (`MegaSpecId`)**: Defines EVM behavior - what the EVM does. Values: `EQUIVALENCE`, `MINI_REX`, `REX`, `REX1`, `REX2`
+- **Hardfork (`MegaHardfork`)**: Defines network upgrade events - when specs are activated. Values: `MiniRex`, `MiniRex1`, `MiniRex2`, `Rex`, `Rex1`, `Rex2`
 
 Multiple hardforks can map to the same spec. For example, both `MiniRex` and `MiniRex2` hardforks use the `MINI_REX` spec.
 
@@ -51,6 +51,20 @@ For complete MiniRex specification, see **[MiniRex.md](./specs/MiniRex.md)**.
 - **MiniRex Foundation**: Inherits all MiniRex features including multidimensional gas model, compute gas detention, and enhanced security
 
 For complete Rex specification, see **[Rex.md](./specs/Rex.md)**.
+
+### REX1 Spec
+
+- **Limit Reset Fix**: Resets compute gas limits at the start of each transaction
+- **No Other Behavioral Changes**: Inherits Rex semantics fully
+
+For complete Rex1 specification, see **[Rex1.md](./specs/Rex1.md)**.
+
+### REX2 Spec
+
+- **SELFDESTRUCT Restored**: Re-enabled with EIP-6780 semantics
+- **Rex1 Baseline**: Inherits Rex1 behavior for all other features
+
+For complete Rex2 specification, see **[Rex2.md](./specs/Rex2.md)**.
 
 ## Quick Start
 

--- a/bin/mega-evme/README.md
+++ b/bin/mega-evme/README.md
@@ -244,7 +244,7 @@ These options are available across all commands.
 
 | Option                 | Default | Description                               |
 | ---------------------- | ------- | ----------------------------------------- |
-| `--state.fork <FORK>`  | MiniRex | Hardfork: `MiniRex`, `Equivalence`, `Rex` |
+| `--state.fork <FORK>`  | MiniRex | Hardfork: `MiniRex`, `Equivalence`, `Rex`, `Rex1`, `Rex2` |
 | `--state.chainid <ID>` | 6342    | Chain ID                                  |
 
 ### Block Environment

--- a/bin/mega-evme/src/common/env.rs
+++ b/bin/mega-evme/src/common/env.rs
@@ -20,8 +20,8 @@ use super::{EvmeError, Result};
 #[derive(Args, Debug, Clone)]
 #[command(next_help_heading = "Chain Options")]
 pub struct ChainArgs {
-    /// Name of spec to use, possible values: `MiniRex`, `Equivalence`, `Rex`
-    #[arg(long = "spec", default_value = "Rex")]
+    /// Name of spec to use, possible values: `MiniRex`, `Equivalence`, `Rex`, `Rex1`, `Rex2`
+    #[arg(long = "spec", default_value = "Rex2")]
     pub spec: String,
 
     /// `ChainID` to use

--- a/bin/mega-evme/src/replay/hardforks.rs
+++ b/bin/mega-evme/src/replay/hardforks.rs
@@ -9,20 +9,23 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::MiniRex1, ForkCondition::Never)
             .with(MegaHardfork::MiniRex2, ForkCondition::Never)
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(1764694618))
-            .with(MegaHardfork::Rex1, ForkCondition::Never),
+            .with(MegaHardfork::Rex1, ForkCondition::Never)
+            .with(MegaHardfork::Rex2, ForkCondition::Never),
         // MegaETH mainnet
         4326 => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
             .with(MegaHardfork::MiniRex1, ForkCondition::Timestamp(1764845637))
             .with(MegaHardfork::MiniRex2, ForkCondition::Timestamp(1764849932))
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(1764851940))
-            .with(MegaHardfork::Rex1, ForkCondition::Never),
+            .with(MegaHardfork::Rex1, ForkCondition::Never)
+            .with(MegaHardfork::Rex2, ForkCondition::Never),
         // Default: all hardforks enabled at genesis
         _ => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
             .with(MegaHardfork::MiniRex1, ForkCondition::Timestamp(0))
             .with(MegaHardfork::MiniRex2, ForkCondition::Timestamp(0))
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(0))
-            .with(MegaHardfork::Rex1, ForkCondition::Timestamp(0)),
+            .with(MegaHardfork::Rex1, ForkCondition::Timestamp(0))
+            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(0)),
     }
 }

--- a/bin/mega-evme/src/run/README.md
+++ b/bin/mega-evme/src/run/README.md
@@ -100,6 +100,9 @@ mega-evme run 0x60016000526001601ff3 --gas 5000000
 
 - `--state.fork <FORK>`: EVM fork/spec (default: mini-rex)
   - `mini-rex`: MegaETH MiniRex hardfork
+  - `rex`: MegaETH Rex hardfork
+  - `rex1`: MegaETH Rex1 hardfork
+  - `rex2`: MegaETH Rex2 hardfork
   - `equivalence`: Optimism Isthmus compatibility mode
 - `--state.chainid <ID>`: Chain ID (default: 6342)
 

--- a/bin/mega-evme/src/t8n/cmd.rs
+++ b/bin/mega-evme/src/t8n/cmd.rs
@@ -88,7 +88,7 @@ pub struct Cmd {
     #[arg(long = "input.txs", default_value = "stdin")]
     pub input_txs: String,
 
-    /// Name of hardfork to use, possible values: `Rex`, `MiniRex`, `Equivalence`
+    /// Name of hardfork to use, possible values: `Rex`, `Rex1`, `Rex2`, `MiniRex`, `Equivalence`
     #[arg(long = "state.fork", default_value = "MiniRex")]
     pub fork: String,
 

--- a/crates/mega-evm/src/block/hardfork.rs
+++ b/crates/mega-evm/src/block/hardfork.rs
@@ -24,6 +24,8 @@ hardfork! {
         Rex,
         /// The fifth hardfork (first patch to Rex).
         Rex1,
+        /// The sixth hardfork (second patch to Rex).
+        Rex2,
     }
 }
 
@@ -37,6 +39,7 @@ impl MegaHardfork {
             Self::MiniRex2 => MegaSpecId::MINI_REX,
             Self::Rex => MegaSpecId::REX,
             Self::Rex1 => MegaSpecId::REX1,
+            Self::Rex2 => MegaSpecId::REX2,
         }
     }
 }
@@ -69,7 +72,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the latest `MegaHardfork` that is active at the given timestamp. If no `MegaHardfork`
     /// is active at the given timestamp, returns `None`.
     fn hardfork(&self, timestamp: u64) -> Option<MegaHardfork> {
-        if self.is_rex_1_active_at_timestamp(timestamp) {
+        if self.is_rex_2_active_at_timestamp(timestamp) {
+            Some(MegaHardfork::Rex2)
+        } else if self.is_rex_1_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex1)
         } else if self.is_rex_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex)
@@ -87,7 +92,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the expected `MegaSpecId` for a block with the given timestamp.
     fn spec_id(&self, timestamp: BlockTimestamp) -> MegaSpecId {
         // Newer hardforks should be checked first
-        if self.is_rex_1_active_at_timestamp(timestamp) {
+        if self.is_rex_2_active_at_timestamp(timestamp) {
+            MegaSpecId::REX2
+        } else if self.is_rex_1_active_at_timestamp(timestamp) {
             MegaSpecId::REX1
         } else if self.is_rex_active_at_timestamp(timestamp) {
             MegaSpecId::REX
@@ -125,6 +132,11 @@ pub trait MegaHardforks: OpHardforks {
     /// Returns `true` if [`MegaHardfork::Rex1`] is active at given block timestamp.
     fn is_rex_1_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.mega_fork_activation(MegaHardfork::Rex1).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`MegaHardfork::Rex2`] is active at given block timestamp.
+    fn is_rex_2_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.mega_fork_activation(MegaHardfork::Rex2).active_at_timestamp(timestamp)
     }
 }
 
@@ -200,6 +212,7 @@ impl MegaHardforkConfig {
         self.insert(MegaHardfork::MiniRex2, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex1, ForkCondition::Timestamp(0));
+        self.insert(MegaHardfork::Rex2, ForkCondition::Timestamp(0));
         self
     }
 

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -375,7 +375,7 @@ impl BlockLimits {
             .with_tx_runtime_limits(tx_runtime_limits)
             .with_block_gas_limit(block_gas_limit);
         match hardfork {
-            MegaHardfork::Rex | MegaHardfork::Rex1 => Self {
+            MegaHardfork::Rex | MegaHardfork::Rex1 | MegaHardfork::Rex2 => Self {
                 block_txs_data_limit: crate::constants::mini_rex::BLOCK_DATA_LIMIT,
                 block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,
                 block_state_growth_limit: crate::constants::rex::BLOCK_STATE_GROWTH_LIMIT,

--- a/crates/mega-evm/src/evm/limit.rs
+++ b/crates/mega-evm/src/evm/limit.rs
@@ -20,7 +20,7 @@ impl EvmTxRuntimeLimits {
         match spec {
             MegaSpecId::EQUIVALENCE => Self::equivalence(),
             MegaSpecId::MINI_REX => Self::mini_rex(),
-            MegaSpecId::REX | MegaSpecId::REX1 => Self::rex(),
+            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 => Self::rex(),
         }
     }
 

--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -13,10 +13,13 @@
 //!
 //! # EVM Specifications
 //!
-//! `MegaETH` supports two EVM specifications:
+//! `MegaETH` supports multiple EVM specifications:
 //!
-//! - **`EQUIVALENCE`**: Maintains equivalence with Optimism Isthmus EVM (default)
+//! - **`EQUIVALENCE`**: Maintains equivalence with Optimism Isthmus EVM
 //! - **`MINI_REX`**: Enhanced version with quadratic LOG costs and disabled SELFDESTRUCT
+//! - **`REX`**: Fixes `MiniRex` call opcode inconsistencies and refines storage gas
+//! - **`REX1`**: Resets compute gas limits between transactions
+//! - **`REX2`**: Re-enables SELFDESTRUCT with EIP-6780 semantics
 
 mod context;
 mod execution;

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -41,7 +41,7 @@ impl MegaPrecompiles {
         let inner = match spec {
             MegaSpecId::EQUIVALENCE => op_revm::precompiles::isthmus(),
             MegaSpecId::MINI_REX => mini_rex(),
-            MegaSpecId::REX | MegaSpecId::REX1 => rex(),
+            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 => rex(),
         };
 
         Self { inner: EthPrecompiles { precompiles: inner, spec: spec.into_eth_spec() }, spec }

--- a/crates/mega-evm/src/evm/spec.rs
+++ b/crates/mega-evm/src/evm/spec.rs
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
 /// - [`SpecId::MINI_REX`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX1`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
+/// - [`SpecId::REX2`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 #[repr(u8)]
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize,
@@ -33,8 +34,10 @@ pub enum MegaSpecId {
     /// The EVM version for the *Rex* hardfork of `MegaETH`.
     REX,
     /// The EVM version for the *Rex1* hardfork of `MegaETH`.
-    #[default]
     REX1,
+    /// The EVM version for the *Rex2* hardfork of `MegaETH`.
+    #[default]
+    REX2,
 }
 
 /// String identifiers for `MegaETH` EVM versions.
@@ -48,6 +51,8 @@ pub mod name {
     pub const REX: &str = "Rex";
     /// The string identifier for the *Rex1* version of the `MegaETH` EVM.
     pub const REX1: &str = "Rex1";
+    /// The string identifier for the *Rex2* version of the `MegaETH` EVM.
+    pub const REX2: &str = "Rex2";
 }
 
 impl MegaSpecId {
@@ -59,7 +64,9 @@ impl MegaSpecId {
     /// Converts the [`SpecId`] into its corresponding [`OpSpecId`].
     pub const fn into_op_spec(self) -> OpSpecId {
         match self {
-            Self::MINI_REX | Self::EQUIVALENCE | Self::REX | Self::REX1 => OpSpecId::ISTHMUS,
+            Self::MINI_REX | Self::EQUIVALENCE | Self::REX | Self::REX1 | Self::REX2 => {
+                OpSpecId::ISTHMUS
+            }
         }
     }
 
@@ -80,6 +87,7 @@ impl From<MegaSpecId> for &'static str {
             MegaSpecId::MINI_REX => name::MINI_REX,
             MegaSpecId::REX => name::REX,
             MegaSpecId::REX1 => name::REX1,
+            MegaSpecId::REX2 => name::REX2,
         }
     }
 }
@@ -94,6 +102,7 @@ impl FromStr for MegaSpecId {
             name::MINI_REX => Ok(Self::MINI_REX),
             name::REX => Ok(Self::REX),
             name::REX1 => Ok(Self::REX1),
+            name::REX2 => Ok(Self::REX2),
             _ => Err(UnknownHardfork),
         }
     }

--- a/crates/mega-evm/tests/mini_rex/disallow_selfdestruct.rs
+++ b/crates/mega-evm/tests/mini_rex/disallow_selfdestruct.rs
@@ -1,4 +1,4 @@
-//! Tests for the disabled SELFDESTRUCT opcode after Mini-Rex hardfork.
+//! Tests for the disabled SELFDESTRUCT opcode in the Mini-Rex spec.
 
 use alloy_primitives::{address, Bytes, U256};
 use mega_evm::{

--- a/crates/mega-evm/tests/rex2/main.rs
+++ b/crates/mega-evm/tests/rex2/main.rs
@@ -1,0 +1,3 @@
+//! Tests for Rex2 hardfork features.
+
+mod selfdestruct;

--- a/crates/mega-evm/tests/rex2/selfdestruct.rs
+++ b/crates/mega-evm/tests/rex2/selfdestruct.rs
@@ -1,0 +1,25 @@
+//! Tests for the SELFDESTRUCT opcode behavior in Rex2.
+
+use alloy_primitives::{address, Bytes, U256};
+use mega_evm::{
+    revm::{
+        bytecode::opcode::{PUSH0, SELFDESTRUCT},
+        context::result::{ExecutionResult, ResultAndState},
+    },
+    test_utils::{transact, MemoryDatabase},
+    *,
+};
+
+#[test]
+fn test_selfdestruct_allowed_in_rex2() {
+    let mut db = MemoryDatabase::default();
+    let contract_address = address!("0000000000000000000000000000000000100001");
+    let code = vec![PUSH0, PUSH0, SELFDESTRUCT];
+    db.set_account_code(contract_address, code.into());
+
+    let caller = address!("0000000000000000000000000000000000100000");
+    let callee = Some(contract_address);
+    let result = transact(MegaSpecId::REX2, &mut db, caller, callee, Bytes::default(), U256::ZERO);
+
+    assert!(matches!(result, Ok(ResultAndState { result: ExecutionResult::Success { .. }, .. })));
+}

--- a/specs/Rex2.md
+++ b/specs/Rex2.md
@@ -1,0 +1,32 @@
+# Rex2 Specification
+
+Rex2 is the second patch to the Rex hardfork. It restores the `SELFDESTRUCT` opcode with
+post-Cancun (EIP-6780) semantics while inheriting all Rex1 behavior.
+
+## Changes from Rex1
+
+### 1. SELFDESTRUCT Re-enabled (EIP-6780)
+
+Rex2 re-enables `SELFDESTRUCT` with EIP-6780 semantics:
+
+- `SELFDESTRUCT` is no longer an invalid opcode.
+- If a contract was **created in the same transaction**, `SELFDESTRUCT` removes the contract and
+  its storage, as in the pre-Cancun behavior.
+- If a contract was **not** created in the same transaction, `SELFDESTRUCT` only transfers the
+  remaining balance to the beneficiary and does **not** delete code or storage.
+
+## Inheritance
+
+Rex2 inherits all Rex1 behavior (including compute gas limit reset between transactions) and all
+features from Rex and MiniRex.
+
+The semantics of Rex2 are inherited from:
+
+- **Rex2** -> **Rex1** -> **Rex** -> **MiniRex** -> **Optimism Isthmus** -> **Ethereum Prague**
+
+## References
+
+- [Rex1 Specification](Rex1.md)
+- [Rex Specification](Rex.md)
+- [MiniRex Specification](MiniRex.md)
+- [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780)


### PR DESCRIPTION
- Added Rex2 hardfork, restoring the SELFDESTRUCT opcode with EIP-6780 semantics.
- Updated documentation to reflect new hardforks (Rex1, Rex2) and their specifications.
- Modified relevant code to support new hardforks in the EVM and updated tests for Rex2 features.
- Enhanced README and command-line options to include Rex1 and Rex2.