### PR TITLE
chore(mega-evme): config Rex1 hardfork timestamp in mega-evme replay config

### DIFF
--- a/bin/mega-evme/src/replay/hardforks.rs
+++ b/bin/mega-evme/src/replay/hardforks.rs
@@ -9,7 +9,7 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::MiniRex1, ForkCondition::Never)
             .with(MegaHardfork::MiniRex2, ForkCondition::Never)
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(1764694618))
-            .with(MegaHardfork::Rex1, ForkCondition::Never)
+            .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766147599))
             .with(MegaHardfork::Rex2, ForkCondition::Never),
         // MegaETH mainnet
         4326 => MegaHardforkConfig::new()


### PR DESCRIPTION
## Summary
- Enable Rex1 hardfork for chain ID 4326 (mainnet) with timestamp 1766282400
- Enable Rex1 hardfork for chain ID 6343 (testnet v2) with timestamp 1766147599

## Test plan
- [x] Verify hardfork activates at the correct timestamp