### PR TITLE
fix: restore version sorting in build.rs using semver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3190,6 +3190,7 @@ version = "1.2.5"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
+ "semver 1.0.26",
  "serde",
  "serde_json",
 ]
@@ -4744,6 +4745,9 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,7 @@ k256 = { version = "0.13.4", default-features = false }
 once_cell = { version = "1.21", default-features = false }
 plain_hasher = { version = "0.2", default-features = false }
 rand = { version = "0.9", default-features = false }
+semver = { version = "1", default-features = false }
 serde = { version = "1.0", default-features = false }
 serde_json = { version = "1.0", default-features = false }
 sha2 = { version = "0.10.9", default-features = false }

--- a/crates/system-contracts/Cargo.toml
+++ b/crates/system-contracts/Cargo.toml
@@ -7,7 +7,8 @@ license.workspace = true
 description = "System contracts for the MegaETH EVM"
 
 [build-dependencies]
-alloy-primitives.workspace = true
+alloy-primitives = { workspace = true, features = ["serde"] }
+semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true, features = ["std"] }
 


### PR DESCRIPTION
## Summary
- Add `semver` crate to sort versioned artifacts by semantic version in build.rs
- This was accidentally removed in PR #133's refactor

## Changes
- Add `semver = "1"` to workspace dependencies
- Use `Version::parse()` and `sort_by_key()` for proper semver sorting
- Ensures reproducible builds with consistent ordering of version constants