### PR TITLE
fix: add empty account for created-and-destructed account

### DIFF
--- a/crates/mega-evm/src/evm/state.rs
+++ b/crates/mega-evm/src/evm/state.rs
@@ -50,6 +50,8 @@ pub fn merge_evm_state(this: &mut EvmState, other: &EvmState) -> usize {
                 account.status.contains(AccountStatus::Created),
                 "Account is selfdestructed but not created. EIP-6780 must be applied."
             );
+            // we will put an empty (equivalent to non-existent) account in the base state.
+            this.insert(*address, Account::default());
             continue;
         }
 


### PR DESCRIPTION
## Summary
- When an account is created and selfdestructed in the same transaction (EIP-6780), insert an empty account into the base state instead of skipping it entirely
- This ensures the state correctly reflects that the account existed and was cleared

## Test plan
- [x] Verified against existing selfdestruct test cases