### PR TITLE
docs(rex2): add KeylessDeploy system contract documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For complete Rex1 specification, see **[Rex1.md](./specs/Rex1.md)**.
 ### REX2 Spec
 
 - **SELFDESTRUCT Restored**: Re-enabled with EIP-6780 semantics
+- **KeylessDeploy System Contract**: Enables keyless deployment (Nick's Method) with custom gas limits
 - **Rex1 Baseline**: Inherits Rex1 behavior for all other features
 
 For complete Rex2 specification, see **[Rex2.md](./specs/Rex2.md)**.

--- a/specs/Rex2.md
+++ b/specs/Rex2.md
@@ -15,6 +15,37 @@ Rex2 re-enables `SELFDESTRUCT` with EIP-6780 semantics:
 - If a contract was **not** created in the same transaction, `SELFDESTRUCT` only transfers the
   remaining balance to the beneficiary and does **not** delete code or storage.
 
+### 2. KeylessDeploy System Contract
+
+Rex2 introduces the **KeylessDeploy** system contract to enable keyless deployment (Nick's Method)
+on MegaETH with custom gas limits.
+
+**System Contract Address**: `0x6342000000000000000000000000000000000003`
+
+**Why it's needed**: MegaETH's gas model prices operations differently than Ethereum. Contracts
+that deploy successfully via keyless transactions on Ethereum may run out of gas on MegaETH.
+Since modifying the signed transaction to increase the gas limit would change the recovered signer
+(and thus the deployment address), a system contract is needed to apply a gas limit override at
+execution time while preserving the original signature.
+
+**Restriction**: The system contract must be called directly in a transaction (`depth == 0`). Calls
+from other contracts will revert with `NotIntercepted()`. This prevents wrap-and-revert attacks
+that could avoid gas charges.
+
+**Interface**:
+
+```solidity
+interface IKeylessDeploy {
+    function keylessDeploy(
+        bytes calldata keylessDeploymentTransaction,
+        uint256 gasLimitOverride
+    ) external returns (uint64 gasUsed, address deployedAddress, bytes memory errorData);
+}
+```
+
+For detailed usage instructions, examples, and security considerations, see the
+[Keyless Deployment documentation](../docs/KEYLESS_DEPLOYMENT.md).
+
 ## Inheritance
 
 Rex2 inherits all Rex1 behavior (including compute gas limit reset between transactions) and all
@@ -30,3 +61,4 @@ The semantics of Rex2 are inherited from:
 - [Rex Specification](Rex.md)
 - [MiniRex Specification](MiniRex.md)
 - [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780)
+- [Keyless Deployment](../docs/KEYLESS_DEPLOYMENT.md)


### PR DESCRIPTION
## Summary

- Add KeylessDeploy system contract section to Rex2 specification
- Document system contract address, purpose, and restrictions
- Add interface signature and link to detailed documentation
- Update README.md with KeylessDeploy feature in Rex2 section

## Test plan

- [x] Verify Rex2.md formatting is consistent with existing style
- [x] Verify links to KEYLESS_DEPLOYMENT.md are correct