### PR TITLE
chore: bump version to 1.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,7 +3122,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3138,7 +3138,7 @@ dependencies = [
  "delegate",
  "derive_more",
  "hex",
- "mega-evm 1.3.0",
+ "mega-evm 1.3.1",
  "mega-system-contracts",
  "once_cell",
  "op-alloy-consensus",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evme"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3170,7 +3170,7 @@ dependencies = [
  "alloy-transport-http",
  "clap",
  "mega-evm 1.0.1",
- "mega-evm 1.3.0",
+ "mega-evm 1.3.1",
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
@@ -3187,7 +3187,7 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -5035,7 +5035,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-test"
-version = "1.3.0"
+version = "1.3.1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -5045,7 +5045,7 @@ dependencies = [
  "hash-db",
  "indicatif",
  "k256",
- "mega-evm 1.3.0",
+ "mega-evm 1.3.1",
  "plain_hasher",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = []
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
 [workspace.package]
-version = "1.3.0"
+version = "1.3.1"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.3.0 to 1.3.1