### PR TITLE
feat: add REX3 spec and Rex3 hardfork

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,13 +52,13 @@ Git submodules are required — clone with `--recursive` or run `git submodule u
 
 ### Spec System (`MegaSpecId`)
 
-Progression: `EQUIVALENCE` → `MINI_REX` → `MINI_REX1` → `MINI_REX2` → `REX` → `REX1` → `REX2`
+Progression: `EQUIVALENCE` → `MINI_REX` → `MINI_REX1` → `MINI_REX2` → `REX` → `REX1` → `REX2` → `REX3`
 
 - **Spec** defines EVM behavior (what the EVM does).
   Defined in `crates/mega-evm/src/evm/spec.rs`.
   The code base **MUST** maintain **backward-compatibility**, which means the semantics (i.e., EVM behaviors) must remain the same for existing specs.
   The only exception for this is the **unstable** spec that is under active development (if exists, must be the latest one).
-  - _At present, there is no unstable spec._
+  - _At present, `REX3` is the unstable spec._
     When a new spec is introduced, this line should be updated to indicate the unstable spec.
   - Specifications of each spec can be found in `./specs`, which should always be maintained to be consistent with the implementation.
 - **Hardfork** (`MegaHardfork`) defines network upgrade events (when specs activate).

--- a/bin/mega-evme/src/common/env.rs
+++ b/bin/mega-evme/src/common/env.rs
@@ -20,8 +20,9 @@ use super::{EvmeError, Result};
 #[derive(Args, Debug, Clone)]
 #[command(next_help_heading = "Chain Options")]
 pub struct ChainArgs {
-    /// Name of spec to use, possible values: `MiniRex`, `Equivalence`, `Rex`, `Rex1`, `Rex2`
-    #[arg(long = "spec", default_value = "Rex2")]
+    /// Name of spec to use, possible values: `MiniRex`, `Equivalence`, `Rex`, `Rex1`, `Rex2`,
+    /// `Rex3`
+    #[arg(long = "spec", default_value = "Rex3")]
     pub spec: String,
 
     /// `ChainID` to use

--- a/bin/mega-evme/src/replay/hardforks.rs
+++ b/bin/mega-evme/src/replay/hardforks.rs
@@ -10,7 +10,8 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::MiniRex2, ForkCondition::Never)
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(1764694618))
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766147599))
-            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770116400)),
+            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770116400))
+            .with(MegaHardfork::Rex3, ForkCondition::Never),
         // MegaETH mainnet
         4326 => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
@@ -18,7 +19,8 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::MiniRex2, ForkCondition::Timestamp(1764849932))
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(1764851940))
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766282400))
-            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770246000)),
+            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770246000))
+            .with(MegaHardfork::Rex3, ForkCondition::Never),
         // Default: all hardforks enabled at genesis
         _ => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
@@ -26,6 +28,7 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::MiniRex2, ForkCondition::Timestamp(0))
             .with(MegaHardfork::Rex, ForkCondition::Timestamp(0))
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(0))
-            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(0)),
+            .with(MegaHardfork::Rex2, ForkCondition::Timestamp(0))
+            .with(MegaHardfork::Rex3, ForkCondition::Timestamp(0)),
     }
 }

--- a/crates/mega-evm/src/block/hardfork.rs
+++ b/crates/mega-evm/src/block/hardfork.rs
@@ -26,6 +26,8 @@ hardfork! {
         Rex1,
         /// The sixth hardfork (second patch to Rex).
         Rex2,
+        /// The seventh hardfork (third patch to Rex).
+        Rex3,
     }
 }
 
@@ -40,6 +42,7 @@ impl MegaHardfork {
             Self::Rex => MegaSpecId::REX,
             Self::Rex1 => MegaSpecId::REX1,
             Self::Rex2 => MegaSpecId::REX2,
+            Self::Rex3 => MegaSpecId::REX3,
         }
     }
 }
@@ -72,7 +75,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the latest `MegaHardfork` that is active at the given timestamp. If no `MegaHardfork`
     /// is active at the given timestamp, returns `None`.
     fn hardfork(&self, timestamp: u64) -> Option<MegaHardfork> {
-        if self.is_rex_2_active_at_timestamp(timestamp) {
+        if self.is_rex_3_active_at_timestamp(timestamp) {
+            Some(MegaHardfork::Rex3)
+        } else if self.is_rex_2_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex2)
         } else if self.is_rex_1_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex1)
@@ -92,7 +97,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the expected `MegaSpecId` for a block with the given timestamp.
     fn spec_id(&self, timestamp: BlockTimestamp) -> MegaSpecId {
         // Newer hardforks should be checked first
-        if self.is_rex_2_active_at_timestamp(timestamp) {
+        if self.is_rex_3_active_at_timestamp(timestamp) {
+            MegaSpecId::REX3
+        } else if self.is_rex_2_active_at_timestamp(timestamp) {
             MegaSpecId::REX2
         } else if self.is_rex_1_active_at_timestamp(timestamp) {
             MegaSpecId::REX1
@@ -137,6 +144,11 @@ pub trait MegaHardforks: OpHardforks {
     /// Returns `true` if [`MegaHardfork::Rex2`] is active at given block timestamp.
     fn is_rex_2_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.mega_fork_activation(MegaHardfork::Rex2).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`MegaHardfork::Rex3`] is active at given block timestamp.
+    fn is_rex_3_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.mega_fork_activation(MegaHardfork::Rex3).active_at_timestamp(timestamp)
     }
 }
 
@@ -213,6 +225,7 @@ impl MegaHardforkConfig {
         self.insert(MegaHardfork::Rex, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex1, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex2, ForkCondition::Timestamp(0));
+        self.insert(MegaHardfork::Rex3, ForkCondition::Timestamp(0));
         self
     }
 

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -389,12 +389,14 @@ impl BlockLimits {
             .with_tx_runtime_limits(tx_runtime_limits)
             .with_block_gas_limit(block_gas_limit);
         match hardfork {
-            MegaHardfork::Rex | MegaHardfork::Rex1 | MegaHardfork::Rex2 => Self {
-                block_txs_data_limit: crate::constants::mini_rex::BLOCK_DATA_LIMIT,
-                block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,
-                block_state_growth_limit: crate::constants::rex::BLOCK_STATE_GROWTH_LIMIT,
-                ..limits
-            },
+            MegaHardfork::Rex | MegaHardfork::Rex1 | MegaHardfork::Rex2 | MegaHardfork::Rex3 => {
+                Self {
+                    block_txs_data_limit: crate::constants::mini_rex::BLOCK_DATA_LIMIT,
+                    block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,
+                    block_state_growth_limit: crate::constants::rex::BLOCK_STATE_GROWTH_LIMIT,
+                    ..limits
+                }
+            }
             MegaHardfork::MiniRex | MegaHardfork::MiniRex2 => Self {
                 block_txs_data_limit: crate::constants::mini_rex::BLOCK_DATA_LIMIT,
                 block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,

--- a/crates/mega-evm/src/constants.rs
+++ b/crates/mega-evm/src/constants.rs
@@ -89,6 +89,11 @@ pub mod rex2 {
     pub const KEYLESS_DEPLOY_OVERHEAD_GAS: u64 = 100_000;
 }
 
+/// Constants for the `REX3` spec.
+pub mod rex3 {
+    // TODO: Add constants for the `REX3` spec.
+}
+
 /// Constants for the `REX` spec.
 pub mod rex {
     /// Additional storage gas cost added to transaction intrinsic gas for the `REX` spec.

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -116,7 +116,7 @@ impl<DB: Database, ExtEnvs: ExternalEnvTypes> MegaInstructions<DB, ExtEnvs> {
                 EthInterpreter,
                 MegaContext<DB, ExtEnvs>,
             >()),
-            MegaSpecId::REX2 => EthInstructions::new(rex2::instruction_table::<
+            MegaSpecId::REX2 | MegaSpecId::REX3 => EthInstructions::new(rex2::instruction_table::<
                 EthInterpreter,
                 MegaContext<DB, ExtEnvs>,
             >()),

--- a/crates/mega-evm/src/evm/limit.rs
+++ b/crates/mega-evm/src/evm/limit.rs
@@ -24,7 +24,7 @@ impl EvmTxRuntimeLimits {
         match spec {
             MegaSpecId::EQUIVALENCE => Self::equivalence(),
             MegaSpecId::MINI_REX => Self::mini_rex(),
-            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 => Self::rex(),
+            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 | MegaSpecId::REX3 => Self::rex(),
         }
     }
 

--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -20,6 +20,7 @@
 //! - **`REX`**: Fixes `MiniRex` call opcode inconsistencies and refines storage gas
 //! - **`REX1`**: Resets compute gas limits between transactions
 //! - **`REX2`**: Re-enables SELFDESTRUCT with EIP-6780 semantics
+//! - **`REX3`**: Introduces per-frame additional limits (unstable)
 
 mod context;
 mod execution;

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -41,7 +41,7 @@ impl MegaPrecompiles {
         let inner = match spec {
             MegaSpecId::EQUIVALENCE => op_revm::precompiles::isthmus(),
             MegaSpecId::MINI_REX => mini_rex(),
-            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 => rex(),
+            MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 | MegaSpecId::REX3 => rex(),
         };
 
         Self { inner: EthPrecompiles { precompiles: inner, spec: spec.into_eth_spec() }, spec }

--- a/crates/mega-evm/src/evm/spec.rs
+++ b/crates/mega-evm/src/evm/spec.rs
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
 /// - [`SpecId::REX`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX1`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX2`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
+/// - [`SpecId::REX3`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 #[repr(u8)]
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize,
@@ -36,8 +37,10 @@ pub enum MegaSpecId {
     /// The EVM version for the *Rex1* hardfork of `MegaETH`.
     REX1,
     /// The EVM version for the *Rex2* hardfork of `MegaETH`.
-    #[default]
     REX2,
+    /// The EVM version for the *Rex3* hardfork of `MegaETH`.
+    #[default]
+    REX3,
 }
 
 /// String identifiers for `MegaETH` EVM versions.
@@ -53,6 +56,8 @@ pub mod name {
     pub const REX1: &str = "Rex1";
     /// The string identifier for the *Rex2* version of the `MegaETH` EVM.
     pub const REX2: &str = "Rex2";
+    /// The string identifier for the *Rex3* version of the `MegaETH` EVM.
+    pub const REX3: &str = "Rex3";
 }
 
 impl MegaSpecId {
@@ -64,9 +69,12 @@ impl MegaSpecId {
     /// Converts the [`SpecId`] into its corresponding [`OpSpecId`].
     pub const fn into_op_spec(self) -> OpSpecId {
         match self {
-            Self::MINI_REX | Self::EQUIVALENCE | Self::REX | Self::REX1 | Self::REX2 => {
-                OpSpecId::ISTHMUS
-            }
+            Self::MINI_REX |
+            Self::EQUIVALENCE |
+            Self::REX |
+            Self::REX1 |
+            Self::REX2 |
+            Self::REX3 => OpSpecId::ISTHMUS,
         }
     }
 
@@ -88,6 +96,7 @@ impl From<MegaSpecId> for &'static str {
             MegaSpecId::REX => name::REX,
             MegaSpecId::REX1 => name::REX1,
             MegaSpecId::REX2 => name::REX2,
+            MegaSpecId::REX3 => name::REX3,
         }
     }
 }
@@ -103,6 +112,7 @@ impl FromStr for MegaSpecId {
             name::REX => Ok(Self::REX),
             name::REX1 => Ok(Self::REX1),
             name::REX2 => Ok(Self::REX2),
+            name::REX3 => Ok(Self::REX3),
             _ => Err(UnknownHardfork),
         }
     }


### PR DESCRIPTION
## Summary

- Add `REX3` variant to `MegaSpecId` (as the new default) and `Rex3` to `MegaHardfork`.
- `REX3` is marked **unstable** and behaves identically to `REX2` for now — no new EVM behavior yet.
- Add empty `rex3` constants module (placeholder for per-frame budget constants).
- Update hardfork configs: `Rex3` is `Never` on testnet/mainnet, `Timestamp(0)` for default.
- Update `mega-evme` CLI default spec to `Rex3`.
- Update `AGENTS.md` to reflect spec progression and unstable status.

## Test plan

- [x] `cargo check -p mega-evm` passes
- [x] `cargo check -p mega-evm --target riscv64imac-unknown-none-elf --no-default-features` passes
- [x] `cargo test -p mega-evm` — all 340 tests pass
- [x] `cargo check -p mega-evme` passes
- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked` passes
- [x] `cargo sort --check --workspace --grouped --order package,workspace,lints,profile,bin,benches,dependencies,dev-dependencies,features` passes