### PR TITLE
feat: increase oracle access compute gas limit to 20M in Rex3

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,7 +58,7 @@ Progression: `EQUIVALENCE` → `MINI_REX` → `MINI_REX1` → `MINI_REX2` → `R
   Defined in `crates/mega-evm/src/evm/spec.rs`.
   The code base **MUST** maintain **backward-compatibility**, which means the semantics (i.e., EVM behaviors) must remain the same for existing specs.
   The only exception for this is the **unstable** spec that is under active development (if exists, must be the latest one).
-  - _At present, both `REX3` and `REX4` are unstable specs._
+  - _At present, `REX4` is the unstable spec._
     When a new spec is introduced, this line should be updated to indicate the unstable spec.
   - Specifications of each spec can be found in `./specs`, which should always be maintained to be consistent with the implementation.
 - **Hardfork** (`MegaHardfork`) defines network upgrade events (when specs activate).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ For complete Rex2 specification, see **[Rex2.md](./specs/Rex2.md)**.
 
 ### REX3 Spec
 
-- **Increased Oracle Access Gas Limit**: Oracle access compute gas limit raised from 1M to 10M, allowing more post-oracle computation
+- **Increased Oracle Access Gas Limit**: Oracle access compute gas limit raised from 1M to 20M, allowing more post-oracle computation
 - **Rex2 Baseline**: Inherits all Rex2 behavior
 
 For complete Rex3 specification, see **[Rex3.md](./specs/Rex3.md)**.

--- a/crates/mega-evm/src/constants.rs
+++ b/crates/mega-evm/src/constants.rs
@@ -92,9 +92,9 @@ pub mod rex2 {
 /// Constants for the `REX3` spec.
 pub mod rex3 {
     /// Gas limit after oracle contract access for the `REX3` spec.
-    /// Increased from 1M (used in `MINI_REX` through `REX2`) to 10M, giving oracle-accessing
+    /// Increased from 1M (used in `MINI_REX` through `REX2`) to 20M, giving oracle-accessing
     /// transactions more room for post-oracle computation.
-    pub const ORACLE_ACCESS_REMAINING_COMPUTE_GAS: u64 = 10_000_000;
+    pub const ORACLE_ACCESS_REMAINING_COMPUTE_GAS: u64 = 20_000_000;
 }
 
 /// Constants for the `REX4` spec.

--- a/docs/BLOCK_AND_TX_LIMITS.md
+++ b/docs/BLOCK_AND_TX_LIMITS.md
@@ -250,11 +250,11 @@ The REX specification is the production-ready hardfork with higher transaction-l
 
 ### REX3 Specification (Increased Oracle Access Compute Gas Limit)
 
-The REX3 specification inherits all REX limits but increases the oracle access compute gas limit from 1M to 10M.
+The REX3 specification inherits all REX limits but increases the oracle access compute gas limit from 1M to 20M.
 
 **Changes from REX/REX1/REX2:**
 
-- `oracle_access_compute_gas_limit` - 10,000,000 gas (10M, up from 1M)
+- `oracle_access_compute_gas_limit` - 20,000,000 gas (20M, up from 1M)
 
 All other limits remain the same as REX.
 

--- a/specs/Rex3.md
+++ b/specs/Rex3.md
@@ -10,10 +10,10 @@ It introduces several behavioral changes while inheriting all Rex2 behavior.
 Rex3 increases the compute gas cap applied after oracle contract access:
 
 - **Previous limit (MINI_REX through REX2):** 1,000,000 (1M) compute gas
-- **New limit (REX3):** 10,000,000 (10M) compute gas
+- **New limit (REX3):** 20,000,000 (20M) compute gas
 
 The block environment access compute gas limit remains unchanged at 20M.
-When both block environment and oracle are accessed, the most restrictive cap still wins (10M from oracle, since 10M < 20M).
+When both block environment and oracle are accessed, both caps are now equal (20M), so neither is more restrictive than the other.
 
 This change allows transactions that read oracle data to perform more computation after the oracle access, reducing the frequency of `VolatileDataAccessOutOfGas` halts for legitimate use cases.
 


### PR DESCRIPTION
## Summary

Increase the Rex3 oracle access compute gas limit from 10M to 20M, giving oracle-accessing transactions more room for post-oracle computation. Also marks Rex3 as a stable spec.

**Changes:**
- Update `rex3::ORACLE_ACCESS_REMAINING_COMPUTE_GAS` constant from 10M to 20M
- Update Rex3 spec, README, AGENTS.md, and BLOCK_AND_TX_LIMITS docs to reflect the new limit
- Fix enforcement test to use 1000 SSTOREs (~22M gas) to exceed the new 20M limit
- Mark Rex3 as stable in AGENTS.md (only REX4 remains unstable)