### PR TITLE
fix: Rex3 system address exemption, doc updates, and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ For complete Rex2 specification, see **[Rex2.md](./specs/Rex2.md)**.
 ### REX3 Spec
 
 - **Increased Oracle Access Gas Limit**: Oracle access compute gas limit raised from 1M to 20M, allowing more post-oracle computation
+- **SLOAD-based Oracle Detention**: Oracle gas detention triggers on SLOAD from oracle storage instead of CALL to oracle contract
+- **Keyless Deploy Compute Gas Tracking**: Records the 100K keyless deploy overhead as compute gas
 - **Rex2 Baseline**: Inherits all Rex2 behavior
 
 For complete Rex3 specification, see **[Rex3.md](./specs/Rex3.md)**.

--- a/crates/mega-evm/src/access/tracker.rs
+++ b/crates/mega-evm/src/access/tracker.rs
@@ -18,15 +18,15 @@ use alloy_primitives::Address;
 ///
 /// # Key Properties
 ///
-/// - **Type-Specific Limits**: Block env/beneficiary access → 20M compute gas, Oracle access → 1M
-///   compute gas
+/// - **Type-Specific Limits**: Block env/beneficiary access → 20M compute gas, Oracle access →
+///   configurable (1M pre-Rex3, 20M Rex3+)
 /// - **Most Restrictive Wins**: Multiple accesses with different limits → minimum limit applied
 /// - **Order Independent**: Oracle→BlockEnv or BlockEnv→Oracle both result in same final limit
 /// - **Compute Gas Only**: Only limits compute gas costs, not storage gas cost
 ///
 /// # Example Flows
 ///
-/// ## Example 1: Block env then oracle (currently 20M > 1M)
+/// ## Example 1: Block env then oracle (pre-Rex3, oracle limit = 1M)
 /// ```ignore
 /// // Transaction starts with compute gas limit of 30M
 /// TIMESTAMP opcode:
@@ -40,7 +40,7 @@ use alloy_primitives::Address;
 /// // Caller applies 1M compute gas limit to AdditionalLimit
 /// ```
 ///
-/// ## Example 2: Oracle then block env (order independent)
+/// ## Example 2: Oracle then block env (pre-Rex3, order independent)
 /// ```ignore
 /// // Transaction starts with compute gas limit of 30M
 /// CALL(oracle) opcode:
@@ -53,6 +53,8 @@ use alloy_primitives::Address;
 ///
 /// // Caller applies 1M compute gas limit to AdditionalLimit
 /// ```
+///
+/// In Rex3+, the oracle access limit is also 20M, so both limits are equal.
 #[derive(Debug, Clone)]
 pub struct VolatileDataAccessTracker {
     /// Unified bitmap tracking all types of volatile data access.

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -80,7 +80,7 @@ use revm::{
 /// implements a global gas detention mechanism:
 /// 1. Remaining gas is immediately limited based on the type of volatile data:
 ///    - Block environment or beneficiary: `BLOCK_ENV_ACCESS_REMAINING_GAS` (20M gas)
-///    - Oracle contract: `ORACLE_ACCESS_REMAINING_GAS` (1M gas)
+///    - Oracle contract: `ORACLE_ACCESS_REMAINING_GAS` (1M gas pre-Rex3, 20M gas Rex3+)
 /// 2. Most restrictive limit wins: If multiple volatile data types are accessed, the minimum (most
 ///    restrictive) limit applies, regardless of access order
 /// 3. Detained gas is tracked and refunded at transaction end

--- a/crates/mega-evm/src/evm/mod.rs
+++ b/crates/mega-evm/src/evm/mod.rs
@@ -20,8 +20,9 @@
 //! - **`REX`**: Fixes `MiniRex` call opcode inconsistencies and refines storage gas
 //! - **`REX1`**: Resets compute gas limits between transactions
 //! - **`REX2`**: Re-enables SELFDESTRUCT with EIP-6780 semantics
-//! - **`REX3`**: Introduces per-frame additional limits (unstable)
-//! - **`REX4`**: Same as REX3 (unstable)
+//! - **`REX3`**: Increases oracle gas limit to 20M, moves oracle detention to SLOAD-based, tracks
+//!   keyless deploy compute gas
+//! - **`REX4`**: Unstable spec under active development
 
 mod context;
 mod execution;

--- a/crates/mega-evm/tests/rex3/main.rs
+++ b/crates/mega-evm/tests/rex3/main.rs
@@ -2,3 +2,4 @@
 
 mod keyless_deploy;
 mod oracle_gas_limit;
+mod system_address;

--- a/crates/mega-evm/tests/rex3/system_address.rs
+++ b/crates/mega-evm/tests/rex3/system_address.rs
@@ -1,0 +1,164 @@
+//! Tests for `MEGA_SYSTEM_ADDRESS` exemption from Rex3 SLOAD-based oracle gas detention.
+
+use alloy_primitives::{address, Bytes, TxKind, U256};
+use mega_evm::{
+    test_utils::{BytecodeBuilder, MemoryDatabase},
+    MegaContext, MegaEvm, MegaSpecId, MegaTransaction, TestExternalEnvs, MEGA_SYSTEM_ADDRESS,
+    ORACLE_CONTRACT_ADDRESS,
+};
+use revm::{
+    bytecode::opcode::{CALL, GAS, POP, PUSH0, SLOAD, STOP},
+    context::TxEnv,
+    handler::EvmTr,
+    inspector::NoOpInspector,
+};
+
+const CALLEE: alloy_primitives::Address = address!("1000000000000000000000000000000000000001");
+
+/// Build bytecode for oracle contract that performs SLOAD(0) and returns.
+fn build_oracle_sload_code() -> Bytes {
+    BytecodeBuilder::default()
+        .append(PUSH0) // key = 0
+        .append(SLOAD) // SLOAD from oracle storage
+        .append(POP)
+        .append(STOP)
+        .build()
+}
+
+/// Test that transactions from `MEGA_SYSTEM_ADDRESS` are exempted from Rex3 SLOAD-based
+/// oracle gas detention.
+///
+/// In Rex3, oracle gas detention triggers on SLOAD from oracle storage. However,
+/// system address transactions should be exempted. This test verifies that the
+/// volatile data tracker does not record oracle access for `MEGA_SYSTEM_ADDRESS` transactions.
+///
+/// The `MEGA_SYSTEM_ADDRESS` must call the oracle contract directly (it's in the whitelist).
+#[test]
+fn test_mega_system_address_exempted_from_rex3_sload_detention() {
+    // Deploy oracle contract code that does SLOAD (this would normally trigger detention)
+    let oracle_code = build_oracle_sload_code();
+
+    let mut db = MemoryDatabase::default();
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
+
+    let external_envs = TestExternalEnvs::<std::convert::Infallible>::new();
+    let mut context =
+        MegaContext::new(&mut db, MegaSpecId::REX3).with_external_envs((&external_envs).into());
+    context.modify_chain(|chain| {
+        chain.operator_fee_scalar = Some(U256::from(0));
+        chain.operator_fee_constant = Some(U256::from(0));
+    });
+
+    // MEGA_SYSTEM_ADDRESS calls oracle directly (oracle is in the whitelist)
+    let tx = TxEnv {
+        caller: MEGA_SYSTEM_ADDRESS,
+        kind: TxKind::Call(ORACLE_CONTRACT_ADDRESS),
+        data: Default::default(),
+        value: U256::ZERO,
+        gas_limit: 1_000_000_000_000,
+        gas_price: 0,
+        ..Default::default()
+    };
+    let mut tx = MegaTransaction::new(tx);
+    tx.enveloped_tx = Some(Bytes::new());
+
+    let mut evm = MegaEvm::new(context).with_inspector(NoOpInspector);
+    let result_envelope = alloy_evm::Evm::transact_raw(&mut evm, tx).unwrap();
+    let result = result_envelope.result;
+
+    // Verify transaction succeeded
+    assert!(result.is_success(), "Transaction from mega system address should succeed");
+
+    // Key assertion: Oracle access should NOT be tracked for mega system address
+    let oracle_accessed = evm
+        .ctx
+        .volatile_data_tracker
+        .try_borrow()
+        .map(|tracker| tracker.has_accessed_oracle())
+        .unwrap_or(false);
+    assert!(
+        !oracle_accessed,
+        "Oracle access should NOT be tracked for transactions from MEGA_SYSTEM_ADDRESS in Rex3"
+    );
+
+    // Verify compute gas limit was NOT set (no gas detention)
+    let compute_gas_limit = evm
+        .ctx
+        .volatile_data_tracker
+        .try_borrow()
+        .map(|tracker| tracker.get_compute_gas_limit())
+        .unwrap_or(None);
+    assert!(
+        compute_gas_limit.is_none(),
+        "Compute gas limit should NOT be set for mega system address transactions"
+    );
+}
+
+/// Test that a non-system address transaction IS subject to Rex3 SLOAD-based oracle
+/// gas detention (contrast with the system address exemption).
+#[test]
+fn test_non_system_address_subject_to_rex3_sload_detention() {
+    let oracle_code = build_oracle_sload_code();
+
+    // Callee calls oracle which does SLOAD
+    let callee_bytecode = BytecodeBuilder::default()
+        .append_many([PUSH0, PUSH0, PUSH0, PUSH0])
+        .push_number(0u8) // value: 0 wei
+        .push_address(ORACLE_CONTRACT_ADDRESS)
+        .append(GAS)
+        .append(CALL)
+        .append(POP)
+        .append(STOP)
+        .build();
+
+    let mut db = MemoryDatabase::default();
+    db.set_account_code(ORACLE_CONTRACT_ADDRESS, oracle_code);
+    db.set_account_code(CALLEE, callee_bytecode);
+
+    let external_envs = TestExternalEnvs::<std::convert::Infallible>::new();
+    let mut context =
+        MegaContext::new(&mut db, MegaSpecId::REX3).with_external_envs((&external_envs).into());
+    context.modify_chain(|chain| {
+        chain.operator_fee_scalar = Some(U256::from(0));
+        chain.operator_fee_constant = Some(U256::from(0));
+    });
+
+    let regular_caller = address!("2000000000000000000000000000000000000002");
+    let tx = TxEnv {
+        caller: regular_caller,
+        kind: TxKind::Call(CALLEE),
+        data: Default::default(),
+        value: U256::ZERO,
+        gas_limit: 1_000_000_000_000,
+        gas_price: 0,
+        ..Default::default()
+    };
+    let mut tx = MegaTransaction::new(tx);
+    tx.enveloped_tx = Some(Bytes::new());
+
+    let mut evm = MegaEvm::new(context).with_inspector(NoOpInspector);
+    let result_envelope = alloy_evm::Evm::transact_raw(&mut evm, tx).unwrap();
+    let result = result_envelope.result;
+
+    assert!(result.is_success(), "Transaction should succeed");
+
+    // Oracle access SHOULD be tracked for non-system address
+    let oracle_accessed = evm
+        .ctx
+        .volatile_data_tracker
+        .try_borrow()
+        .map(|tracker| tracker.has_accessed_oracle())
+        .unwrap_or(false);
+    assert!(
+        oracle_accessed,
+        "Oracle access SHOULD be tracked for regular address transactions in Rex3"
+    );
+
+    // Compute gas limit should be set to 20M
+    let compute_gas_limit = evm.ctx_ref().additional_limit.borrow().compute_gas_limit;
+    assert_eq!(
+        compute_gas_limit,
+        mega_evm::constants::rex3::ORACLE_ACCESS_REMAINING_COMPUTE_GAS,
+        "Compute gas limit should be 20M for regular transactions accessing oracle in Rex3"
+    );
+}

--- a/docs/BLOCK_AND_TX_LIMITS.md
+++ b/docs/BLOCK_AND_TX_LIMITS.md
@@ -255,6 +255,9 @@ The REX3 specification inherits all REX limits but increases the oracle access c
 **Changes from REX/REX1/REX2:**
 
 - `oracle_access_compute_gas_limit` - 20,000,000 gas (20M, up from 1M)
+- Oracle gas detention now triggers on SLOAD from oracle storage instead of CALL to oracle contract.
+  This means simply calling the oracle without reading storage no longer activates gas detention.
+- Keyless deploy overhead gas (100K) is now recorded as compute gas, counting toward the 200M per-transaction compute gas limit.
 
 All other limits remain the same as REX.
 


### PR DESCRIPTION
## Summary

- Add `MEGA_SYSTEM_ADDRESS` exemption to the Rex3 SLOAD-based oracle gas detention path in `host.rs`. Without this, system transactions that read oracle storage would be incorrectly subject to gas detention.
- Update Rex3.md spec to document SLOAD-based detention semantics (caller-agnostic triggering, DELEGATECALL escape, system address exemption semantic difference from pre-Rex3 CALL-based path).
- Fix stale documentation referencing hardcoded "1M" oracle gas limits across tracker.rs, instructions.rs, mod.rs, README.md, and BLOCK_AND_TX_LIMITS.md.
- Add 8 new tests covering system address exemption, non-oracle SLOAD, nested call chains, combined block env + oracle limits, sendHint interception, and keyless deploy compute gas limit enforcement.

## Changes

| File | Change |
|------|--------|
| `crates/mega-evm/src/evm/host.rs` | Add `MEGA_SYSTEM_ADDRESS` exemption to Rex3 SLOAD oracle detention |
| `specs/Rex3.md` | Document SLOAD semantics, fix grammar |
| `README.md` | Add 2 missing Rex3 features |
| `crates/mega-evm/src/evm/mod.rs` | Fix Rex3/Rex4 doc comments |
| `crates/mega-evm/src/evm/instructions.rs` | Fix stale 1M gas reference |
| `crates/mega-evm/src/access/tracker.rs` | Fix stale 1M gas references in examples |
| `docs/BLOCK_AND_TX_LIMITS.md` | Add SLOAD + keyless deploy to Rex3 section |
| `crates/mega-evm/tests/rex3/system_address.rs` | New: 2 system address exemption tests |
| `crates/mega-evm/tests/rex3/oracle_gas_limit.rs` | Add 4 new oracle SLOAD tests |
| `crates/mega-evm/tests/rex3/keyless_deploy.rs` | Add 1 compute gas limit test |
| `crates/mega-evm/tests/rex3/main.rs` | Add `mod system_address` |

## Test plan

- [x] `cargo check -p mega-evm` passes
- [x] `cargo test -p mega-evm` — all 311 tests pass (15 rex3 tests, including 8 new)
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked` — clean