### PR TITLE
ci: add Claude PR review workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,6 +26,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow for automated Claude PR reviews
- Triggers on PR open/update and interactive `@claude` mentions in comments
- Restricts interactive triggers to repo members, collaborators, and owners via `author_association` check to prevent external token abuse
- Uses OAuth token authentication (`CLAUDE_CODE_OAUTH_TOKEN`) for subscription-based billing

## Test plan
- Open a test PR and verify Claude automatically reviews it
- Comment `@claude` on a PR as a repo member and verify it responds
- Verify external contributors' `@claude` comments are ignored