### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/no_std.yml
+++ b/.github/workflows/no_std.yml
@@ -4,6 +4,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/megaeth-labs/mega-evm/security/code-scanning/2](https://github.com/megaeth-labs/mega-evm/security/code-scanning/2)

In general, the fix is to explicitly set `permissions` for the workflow or the job so that the `GITHUB_TOKEN` has only the minimal required scopes. For this workflow, the steps are all read-only with respect to the repository (checkout code, install tools, run `cargo check`), so `contents: read` is sufficient. No step requires pushing commits, creating releases, modifying issues, etc.

The best way to fix this without changing existing functionality is to add a root-level `permissions` block that applies to all jobs in the workflow. This keeps the YAML concise and ensures any future jobs inherit the minimal permissions by default, unless they explicitly override them. Concretely, in `.github/workflows/no_std.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `concurrency:` block (for clarity and common convention). No imports or additional definitions are needed; this is standard GitHub Actions YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
