### PR TITLE
ci: fix dependabot label check bypass

### DIFF
--- a/.github/workflows/pr-label-check.yml
+++ b/.github/workflows/pr-label-check.yml
@@ -10,7 +10,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Check for required labels
-        if: github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.user.login != 'dependabot[bot]'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |


### PR DESCRIPTION
## Summary

- Fix the dependabot label check bypass by using `github.event.pull_request.user.login` instead of `github.actor`.

`github.actor` is whoever triggered the workflow run (e.g., a human who labeled or reopened the PR), not the PR author.
This caused the label check to run on dependabot PRs when a human interacted with them.
`github.event.pull_request.user.login` always refers to the PR author regardless of who triggered the event.

## Test plan

- [ ] Re-run the label check on [PR #196](https://github.com/megaeth-labs/mega-evm/pull/196) after merging and verify it passes.