### PR TITLE
test: add Rex4 system contract deployment and idempotence tests -v2

### DIFF
--- a/crates/mega-evm/tests/rex4/deployment.rs
+++ b/crates/mega-evm/tests/rex4/deployment.rs
@@ -2,7 +2,7 @@
 
 use alloy_evm::{block::BlockExecutor, Database, Evm, EvmEnv, EvmFactory};
 use alloy_op_evm::block::receipt_builder::OpAlloyReceiptBuilder;
-use alloy_primitives::{Address, B256, Bytes};
+use alloy_primitives::{Address, Bytes, B256};
 use mega_evm::{
     test_utils::MemoryDatabase, BlockLimits, EmptyExternalEnv, MegaBlockExecutionCtx,
     MegaBlockExecutor, MegaEvm, MegaEvmFactory, MegaHardfork, MegaHardforkConfig, MegaSpecId,
@@ -10,8 +10,10 @@ use mega_evm::{
     LIMIT_CONTROL_CODE, LIMIT_CONTROL_CODE_HASH,
 };
 use revm::{
-    context::BlockEnv, database::State, inspector::NoOpInspector, primitives::KECCAK_EMPTY,
-    primitives::U256,
+    context::BlockEnv,
+    database::State,
+    inspector::NoOpInspector,
+    primitives::{KECCAK_EMPTY, U256},
 };
 
 type TestState<'db> = State<&'db mut MemoryDatabase>;
@@ -85,11 +87,7 @@ fn assert_contract_deployed<DB: Database>(
     );
 }
 
-fn assert_contract_not_deployed<DB: Database>(
-    db: &mut State<DB>,
-    address: Address,
-    name: &str,
-) {
+fn assert_contract_not_deployed<DB: Database>(db: &mut State<DB>, address: Address, name: &str) {
     let cache_acc = db.load_cache_account(address).expect("should load cache account");
     let code_hash = cache_acc.account_info().map_or(KECCAK_EMPTY, |info| info.code_hash);
     assert_eq!(code_hash, KECCAK_EMPTY, "{name} should not have deployed code for this spec");

--- a/crates/mega-evm/tests/rex4/main.rs
+++ b/crates/mega-evm/tests/rex4/main.rs
@@ -1,8 +1,8 @@
 //! Tests for `Rex4` hardfork features.
 
 mod access_control;
-mod eip7702_delegation_cycle;
 mod deployment;
+mod eip7702_delegation_cycle;
 mod frame_limits;
 mod frame_state_growth;
 mod gas_detention;


### PR DESCRIPTION
## Summary
Adds Rex4 deployment tests for `MegaAccessControl` and `MegaLimitControl`, covering:
- activation on Rex4
- idempotent repeated `apply_pre_execution_changes()`
- Rex3 boundary behavior (not deployed before Rex4)

Also incorporates the requested review follow-up:
- use production-like hardfork activation with `with_all_activated()`
- check `KECCAK_EMPTY` for the non-deployed case
- extract repeated executor setup into a shared helper

## Note
This PR replaces #187, which got stuck due to a GitHub fork-lineage issue after the repository outage. All review feedback from Troublor has been incorporated here. Please consider closing #187 in favor of this one.
