### PR TITLE
docs: clarify contract creation storage gas does not include account creation cost

### DIFF
--- a/docs/DUAL_GAS_MODEL.md
+++ b/docs/DUAL_GAS_MODEL.md
@@ -85,9 +85,8 @@ Applied when creating a contract through CREATE/CREATE2 opcodes or contract crea
 | **MiniRex** | `2,000,000 × multiplier`    | 2,000,000    | 4,000,000    | 8,000,000    |
 | **Rex**     | `32,000 × (multiplier - 1)` | 0            | 32,000       | 96,000       |
 
-**Note**: In Rex, contract creation pays both:
-1. Contract creation storage gas: `32,000 × (multiplier - 1)`
-2. Account creation storage gas: `25,000 × (multiplier - 1)` (if creating a new account)
+**Note**: Contract creation storage gas subsumes account creation cost — only `32,000 × (multiplier - 1)` is charged.
+Account creation storage gas applies only to CALL-initiated account creation, not to contract creation.
 
 In MiniRex, contract creation used the same formula as account creation.
 

--- a/specs/Rex.md
+++ b/specs/Rex.md
@@ -44,7 +44,8 @@ Applied when:
 
 - Value transfer to non-existent account
 - CALL or CALLCODE with non-zero value to empty account (EIP-161)
-- Contract creation uses separate cost (see 2.2.3)
+
+Contract creation does not charge account creation storage gas; it has its own cost (see 2.2.3).
 
 #### 2.2.3 Contract Creation Storage Gas
 
@@ -58,10 +59,8 @@ Applied when:
 - CREATE or CREATE2 opcode
 - Contract creation transaction
 
-Contract creation pays both:
-
-1. Contract creation storage gas: `32,000 × (multiplier - 1)`
-2. Account creation storage gas: `25,000 × (multiplier - 1)` (if new account)
+Contract creation storage gas already subsumes account creation cost.
+Account creation storage gas does not apply to contract creation.
 
 #### 2.2.4 Storage Gas Summary
 


### PR DESCRIPTION
## Summary

- Fix incorrect statement in Rex spec and DUAL_GAS_MODEL doc that contract creation pays **both** contract creation storage gas (32K×(m-1)) and account creation storage gas (25K×(m-1)). 
- Contract creation storage gas subsumes the account creation cost — only 32K×(m-1) is charged. Account creation storage gas (25K×(m-1)) applies only to CALL-initiated account creation (value transfer to empty account).
- The Rust implementation was already correct; only the spec and doc text were wrong.