### PR TITLE
chore: bump version to 1.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evme"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2986,7 +2986,7 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -4811,7 +4811,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-test"
-version = "1.4.2"
+version = "1.5.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = []
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
 [workspace.package]
-version = "1.4.2"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.86"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.4.2 to 1.5.0