### PR TITLE
ci: add agent-based documentation audit CI

### DIFF
--- a/.claude/skills/doc-correctness/SKILL.md
+++ b/.claude/skills/doc-correctness/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: doc-correctness
+description: Verifies documentation claims in docs/ against implementation source code in this repository. Use when cross-checking doc accuracy, auditing constants and addresses, verifying spec correctness, or validating behavioral rules against source.
+---
+
+# Documentation Correctness Verification
+
+Verify factual claims in the documentation against implementation source: $ARGUMENTS
+
+Parse the arguments to determine scope.
+Accepted inputs:
+
+- A single page path (e.g., `docs/evm/dual-gas-model.md`) — verify claims on that page.
+- A directory (e.g., `docs/evm/`) — verify all pages in that directory.
+- A claim family (e.g., `gas`, `system-contracts`, `upgrades`, `agent-files`) — verify all claims of that type across all pages.
+- `all` — verify every page listed in `docs/SUMMARY.md` plus all agent files (`AGENTS.md`, `CLAUDE.md`, `docs/AGENTS.md`, `REVIEW.md`, `.claude/skills/*/SKILL.md`).
+
+Default (no arguments): verify all pages.
+
+## Claim Families
+
+Every verifiable claim in the docs falls into one of these families.
+
+| Family | What to verify | Key source locations |
+|--------|---------------|---------------------|
+| Gas | Gas costs, limits, compute gas caps, storage gas bases, detention caps, refund rules, multipliers | `crates/mega-evm/src/constants.rs`, `crates/mega-evm/src/evm/instructions.rs`, `crates/mega-evm/src/external/gas.rs` |
+| System Contracts | Addresses, Solidity interfaces, execution semantics, deployment specs, interception behavior | `crates/system-contracts/contracts/`, `crates/mega-evm/src/system/`, address constants in `constants.rs` |
+| Resource Limits | Per-transaction limits (compute gas, data size, KV updates, state growth), per-frame limits, forwarding rules | `crates/mega-evm/src/constants.rs`, `crates/mega-evm/src/limit/` |
+| Detention | Gas detention caps, volatile data categories, detention trigger conditions | `crates/mega-evm/src/constants.rs`, `crates/mega-evm/src/access/`, `crates/mega-evm/src/evm/host.rs` |
+| Upgrades | Spec progression, per-upgrade behavioral deltas, activation order, backward compatibility | `crates/mega-evm/src/evm/spec.rs`, `crates/mega-evm/src/block/hardfork.rs` |
+| Precompiles | Precompile addresses, behavior, gas costs | `crates/mega-evm/src/evm/precompiles.rs` |
+| Agent Files | Spec progression lists, system contract tables, source layout descriptions, code path references, unstable spec markers in `AGENTS.md`, `CLAUDE.md`, `docs/AGENTS.md`, `REVIEW.md`, and `.claude/skills/*/SKILL.md` | Same sources as the claim's primary family (spec progression → `spec.rs`, system contracts → `constants.rs` + `crates/system-contracts/`, source layout → actual directory structure) |
+
+### Agent File Verification
+
+Agent instruction files (`AGENTS.md`, `CLAUDE.md`, `docs/AGENTS.md`, `REVIEW.md`, `.claude/skills/*/SKILL.md`) contain code-related claims that can go stale.
+Treat them as additional pages to audit.
+Key claims to verify:
+
+- **Spec progression list** in `AGENTS.md`: Does it match the actual `MegaSpecId` enum in `spec.rs`?
+- **Unstable spec marker** in `AGENTS.md`: Is the marked unstable spec still the latest?
+- **System Contracts table** in `AGENTS.md`: Do the contracts, addresses, and purposes match the source?
+- **Core Source Layout** in `AGENTS.md`: Do the listed modules and descriptions match the actual directory structure?
+- **Code-to-doc mapping tables** in skill files: Are all doc pages and code paths still valid?
+- **Hardfork-to-spec mapping** in `AGENTS.md`: Does it match `hardfork.rs`?
+- **Test organization** in `AGENTS.md`: Does it match actual test directory structure?
+
+## Workflow
+
+### Phase 1: Claim Extraction
+
+Read the target page(s) and extract every verifiable claim.
+A claim is any statement that can be checked against source code:
+
+- **Numeric values**: gas costs, limits, caps, multipliers, addresses, bucket sizes.
+- **Behavioral rules**: "X always/never happens", "Y reverts when Z", "A is charged before B".
+- **Interface definitions**: function signatures, event signatures, error selectors, parameter names.
+- **Relationships**: "Spec X introduced feature Y", "Contract Z is available since Rex2".
+- **Security claims**: Attack vectors, invariants, and risk consequences stated in Security Considerations sections.
+
+For each claim, record:
+
+- The exact text from the doc.
+- The page path and section.
+- The claim family.
+
+### Phase 2: Source Resolution
+
+For each claim, locate the authoritative source:
+
+1. **Match the claim family** to the source locations in the table above.
+2. **Find the specific source**: search for the constant name, function signature, address, or behavioral code path.
+   - For constants: grep for the constant name or numeric value in `crates/mega-evm/src/constants.rs` and related files.
+   - For interfaces: read the Solidity contract source in `crates/system-contracts/contracts/`.
+   - For upgrade claims: check `spec.rs` and `hardfork.rs` for the spec gate.
+   - For behavioral rules: trace the code path that implements the rule.
+
+**Budget**: Do not spend more than ~5 targeted file reads per claim.
+If the source cannot be found after 5 reads, mark the claim as Ambiguous.
+
+### Phase 3: Verification
+
+For each claim, compare the doc text against the source and assign a disposition:
+
+| Disposition | Meaning |
+|-------------|---------|
+| **Verified** | Doc matches source exactly. Record: file path and line number. |
+| **Incorrect** | Doc contradicts source. Record: what the doc says, what the source says, and the source location. |
+| **Stale** | Doc was correct for a previous spec but is outdated. Record: which spec introduced the change. |
+| **Ambiguous** | Source is unclear or claim cannot be verified. Record: what was searched and why. |
+| **Version-dependent** | Claim is correct for some specs but not others, and the doc doesn't specify which. |
+
+### Phase 4: Report
+
+```markdown
+## Correctness
+
+**Scope**: {what was verified}
+**Claims checked**: {count}
+
+### Summary
+
+| Disposition | Count |
+|-------------|-------|
+| Verified | N |
+| Incorrect | N |
+| Stale | N |
+| Ambiguous | N |
+| Version-dependent | N |
+
+### Findings (Incorrect / Stale / Ambiguous / Version-dependent only)
+
+#### C-001: {short description}
+
+- **Severity**: Blocker | Major | Minor
+- **Disposition**: {disposition}
+- **Claim family**: {family}
+- **Page**: {path}
+- **Section**: {heading}
+- **Doc says**: "{exact text from doc}"
+- **Source says**: "{what the source actually shows}"
+- **Source location**: `{file}:{line}`
+- **Suggested correction**: {concrete edit to the doc text}
+
+#### C-002: ...
+
+### Verified Claims
+
+<details>
+<summary>N claims verified</summary>
+
+| # | Page | Claim | Source | Line |
+|---|------|-------|--------|------|
+| 1 | {path} | {claim summary} | `{file}` | {line} |
+
+</details>
+```
+
+**Severity definitions**:
+
+- **Blocker**: Incorrect numeric values (gas costs, limits, addresses), wrong spec attribution, wrong interface signature — would cause implementation bugs.
+- **Major**: Stale values from a previous spec, missing version qualification, misleading behavioral description.
+- **Minor**: Ambiguous claim that could be misread, minor wording imprecision that doesn't change meaning.
+
+## Rules
+
+- Verify against actual source code, not against other documentation pages.
+- If a claim references a specific spec (e.g., "Rex3 introduced X"), verify it was indeed that spec, not an earlier or later one.
+- Do NOT fix the issues yourself unless the user explicitly asks. This skill produces a report, not edits.
+- When verifying gas constants, check both the constant definition AND its usage context (per-transaction? per-opcode? per-block?).
+- When verifying Security Considerations claims, confirm that the stated invariant is real — check that the code actually enforces it.
+- Every numeric value MUST be verified against `crates/mega-evm/src/constants.rs` or the relevant source file. Do not trust other documentation pages as a source of truth.

--- a/.claude/skills/doc-freshness/SKILL.md
+++ b/.claude/skills/doc-freshness/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: doc-freshness
+description: Detects recent code changes in mega-evm that are not yet reflected in docs/. Use when checking for documentation gaps, auditing doc coverage after a release, looking for undocumented changes, or running a periodic doc sweep.
+---
+
+# Documentation Freshness Check
+
+Check for undocumented code changes in this repository: $ARGUMENTS
+
+Parse the arguments to determine the time window.
+Accepted inputs:
+
+- A duration (e.g., `7d`, `14d`, `30d`) — check merged PRs in that window.
+- A date (e.g., `2025-03-01`) — check merged PRs since that date.
+- A git ref or tag (e.g., `v0.5.0`) — check merged PRs since that ref.
+
+Default (no arguments): last 14 days.
+
+## What Is Doc-Worthy
+
+A change is doc-worthy if it affects the behavior specified in `docs/`.
+The documentation in `docs/` is the formal MegaETH specification covering EVM execution, gas accounting, resource limits, system contracts, and upgrade history.
+
+**Always doc-worthy** (auto-include):
+
+- New or modified gas constants or limits
+- New or modified system contract (address, interface, behavior)
+- New spec or hardfork introduction
+- Opcode behavior changes
+- Resource limit changes (compute gas, data size, KV updates, state growth)
+- Gas detention rule changes
+- Precompile behavior changes
+- SELFDESTRUCT semantics changes
+
+**Usually doc-worthy** (include if impact is significant):
+
+- New external environment dependencies
+- Changes to block execution logic
+- Changes to gas forwarding or call frame semantics
+
+**Internal-only** (exclude):
+
+- Pure refactoring with no behavioral change
+- Test-only changes
+- CI/CD pipeline changes
+- Dependency bumps (unless they change behavior)
+- Build system changes
+- CLI tool (`mega-evme`) changes (not part of the spec)
+- Benchmark changes
+
+When uncertain, include the PR as "Possibly doc-worthy" with a note on why it's ambiguous.
+
+## Code-to-Doc Mapping
+
+| Code path | Affected doc pages |
+|-----------|-------------------|
+| `crates/mega-evm/src/constants.rs` | `docs/evm/dual-gas-model.md`, `docs/evm/resource-limits.md`, `docs/evm/gas-detention.md`, `docs/evm/gas-forwarding.md`, `docs/evm/contract-limits.md` |
+| `crates/mega-evm/src/evm/spec.rs` | `docs/hardfork-spec.md`, `docs/upgrades/overview.md`, `docs/evm/overview.md` |
+| `crates/mega-evm/src/evm/instructions.rs` | `docs/evm/dual-gas-model.md`, `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/evm/host.rs` | `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/evm/precompiles.rs` | `docs/evm/precompiles.md` |
+| `crates/mega-evm/src/block/` | `docs/hardfork-spec.md`, `docs/evm/overview.md` |
+| `crates/mega-evm/src/limit/` | `docs/evm/resource-limits.md`, `docs/evm/resource-accounting.md` |
+| `crates/mega-evm/src/access/` | `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/system/` | `docs/system-contracts/*.md` |
+| `crates/mega-evm/src/external/` | `docs/evm/dual-gas-model.md`, `docs/system-contracts/oracle.md` |
+| `crates/system-contracts/contracts/` | `docs/system-contracts/*.md` |
+
+### Agent and Skill Files
+
+Code changes can also make agent instruction files stale.
+These files contain code paths, constant names, system contract tables, and spec references that must stay in sync with the implementation.
+
+| Code path | Affected agent files |
+|-----------|---------------------|
+| `crates/mega-evm/src/evm/spec.rs` | `AGENTS.md` (spec progression list, unstable spec marker), `CLAUDE.md` |
+| `crates/mega-evm/src/block/hardfork.rs` | `AGENTS.md` (hardfork-to-spec mapping) |
+| `crates/mega-evm/src/` (new/renamed modules) | `AGENTS.md` (Core Source Layout section) |
+| `crates/system-contracts/contracts/` (new contract) | `AGENTS.md` (System Contracts table) |
+| `crates/mega-evm/src/constants.rs` | `AGENTS.md` (Key Concepts sections referencing constant names) |
+| `crates/mega-evm/src/system/` | `AGENTS.md`, `.claude/skills/doc-impact-check/SKILL.md`, `.claude/skills/doc-freshness/SKILL.md` (code-to-doc mapping tables) |
+| `crates/mega-evm/src/limit/` (new tracker) | `AGENTS.md` (Multidimensional Resource Limits section) |
+| `docs/` (new pages added to SUMMARY.md) | `.claude/skills/doc-impact-check/SKILL.md`, `.claude/skills/doc-freshness/SKILL.md` (mapping tables need new entries) |
+
+## Workflow
+
+### Phase 1: Collect Recent Changes
+
+Collect merged PRs in the time window:
+
+```bash
+gh pr list --repo megaeth-labs/mega-evm --state merged --search "merged:>={since_date}" --json number,title,url,mergedAt,labels,body --limit 100
+```
+
+If `gh` is not available, fall back to local git log:
+
+```bash
+git log --oneline --since="{since_date}" --merges -- .
+```
+
+For each PR, record:
+
+- PR number and title
+- Merge date
+- Labels (if any)
+- A one-line summary of what changed
+
+### Phase 2: Triage
+
+Classify each PR as **doc-worthy** or **internal-only** using the criteria above.
+Check PR titles AND bodies — some PRs have uninformative titles but detailed bodies.
+When a PR touches both doc-worthy and internal code, classify based on the doc-worthy parts.
+
+### Phase 3: Coverage Search
+
+For each doc-worthy change:
+
+1. Use the code-to-doc mapping to identify target pages, including agent/skill files.
+2. Search `docs/` and agent files (`AGENTS.md`, `CLAUDE.md`, `.claude/skills/`) for existing coverage of the feature/constant/behavior.
+3. Read the target page(s) and agent file(s) to check if the change is reflected.
+
+Classify coverage:
+
+- **Covered**: The change is already documented accurately.
+- **Partially covered**: The feature is mentioned but the specific change is not reflected (e.g., old values, missing new parameters).
+- **Not covered**: No mention found in any documentation page.
+
+For each gap, also check whether agent files (`AGENTS.md`, `CLAUDE.md`, `.claude/skills/*/SKILL.md`) reference the affected area and need updating.
+Record this in the "Agent file impact" field of the gap finding.
+
+### Phase 4: Prioritize Gaps
+
+| Priority | Criteria |
+|----------|----------|
+| **P0** | Incorrect values live in docs, security-relevant, or new spec with no upgrade page |
+| **P1** | New behavioral change that implementers need to know about |
+| **P2** | Minor parameter change, non-breaking addition, or enhancement to existing feature |
+
+### Phase 5: Report
+
+```markdown
+## Freshness
+
+**Time window**: {since} to {now}
+**PRs reviewed**: {total count}
+**Doc-worthy changes**: {count}
+**Coverage gaps found**: {count}
+
+### Gaps (ordered by priority)
+
+#### F-001: {short description}
+
+- **Priority**: P0 | P1 | P2
+- **Source**: PR #{number} — {title} ({url})
+- **Merged**: {date}
+- **What changed**: {description of the behavioral change}
+- **Coverage**: Not covered | Partially covered
+- **Target page**: {doc page path that needs updating}
+- **Agent file impact**: {agent files affected, e.g., "AGENTS.md (system contract table)" or "None"}
+- **What needs updating**: {specific content that needs to change}
+
+#### F-002: ...
+
+### Covered Changes
+
+<details>
+<summary>N changes already documented</summary>
+
+| # | PR | Change | Documented in |
+|---|-----|--------|---------------|
+| 1 | #{number} | {summary} | `{doc page}` |
+
+</details>
+
+### Internal-Only Changes
+
+<details>
+<summary>N internal changes excluded</summary>
+
+| # | PR | Why excluded |
+|---|-----|-------------|
+| 1 | #{number} — {title} | {reason} |
+
+</details>
+```
+
+## Rules
+
+- Always check PR titles AND bodies when triaging.
+- If the time window returns more than 100 PRs, note this and suggest narrowing the window.
+- Do NOT create or edit documentation pages. This skill produces a gap report only.
+- When suggesting target pages, prefer updating existing pages over creating new ones.
+- Include the PR URL for every finding so the reader can review the actual change.

--- a/.claude/skills/doc-impact-check/SKILL.md
+++ b/.claude/skills/doc-impact-check/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: doc-impact-check
+description: Analyzes a PR diff to determine if documentation under docs/ needs updating. Use when a PR modifies EVM behavior, gas constants, system contracts, opcode semantics, resource limits, or spec definitions in mega-evm source code.
+---
+
+# PR Documentation Impact Check
+
+Analyze the current PR diff to determine whether documentation under `docs/` needs updating.
+
+## Context
+
+This skill runs in CI on pull requests that modify source code under `crates/mega-evm/src/` or `crates/system-contracts/`.
+It checks whether the code changes affect documented behavior and whether the PR already includes corresponding doc updates.
+
+The documentation in `docs/` is the formal MegaETH specification.
+Read `docs/AGENTS.md` for the writing rules and conventions.
+
+## Code-to-Doc Mapping
+
+Use this mapping to identify which doc pages are potentially affected by code changes.
+
+| Code path | What changes here | Affected doc pages |
+|-----------|-------------------|--------------------|
+| `crates/mega-evm/src/constants.rs` | Gas limits, resource limits, detention caps, multipliers | `docs/evm/dual-gas-model.md`, `docs/evm/resource-limits.md`, `docs/evm/gas-detention.md`, `docs/evm/gas-forwarding.md`, `docs/evm/contract-limits.md` |
+| `crates/mega-evm/src/evm/spec.rs` | Spec definitions, spec progression | `docs/hardfork-spec.md`, `docs/upgrades/overview.md`, `docs/evm/overview.md` |
+| `crates/mega-evm/src/evm/instructions.rs` | Opcode behavior, compute gas wrapping, gas detention enforcement | `docs/evm/dual-gas-model.md`, `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/evm/host.rs` | Host hooks, volatile data access tracking | `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/evm/precompiles.rs` | Precompile behavior | `docs/evm/precompiles.md` |
+| `crates/mega-evm/src/block/` | Block execution, hardfork mapping, executor | `docs/hardfork-spec.md`, `docs/evm/overview.md` |
+| `crates/mega-evm/src/limit/` | Resource limit tracking (compute gas, data size, KV updates, state growth) | `docs/evm/resource-limits.md`, `docs/evm/resource-accounting.md` |
+| `crates/mega-evm/src/limit/storage_call_stipend.rs` | Storage gas stipend lifecycle | `docs/evm/gas-forwarding.md` |
+| `crates/mega-evm/src/access/` | Block env access tracking, volatile data detection | `docs/evm/gas-detention.md` |
+| `crates/mega-evm/src/system/` | System contract integration, call interception | `docs/system-contracts/*.md` |
+| `crates/mega-evm/src/external/` | SALT environment, oracle environment, dynamic gas cost | `docs/evm/dual-gas-model.md`, `docs/system-contracts/oracle.md` |
+| `crates/system-contracts/contracts/` | Solidity system contract sources | `docs/system-contracts/*.md` |
+
+### Agent and Skill Files
+
+Code changes can also make agent instruction files stale.
+These files contain code paths, constant names, system contract tables, and spec references that must stay in sync with the implementation.
+
+| Code path | Affected agent files |
+|-----------|---------------------|
+| `crates/mega-evm/src/evm/spec.rs` | `AGENTS.md` (spec progression list, unstable spec marker), `CLAUDE.md` (same content) |
+| `crates/mega-evm/src/block/hardfork.rs` | `AGENTS.md` (hardfork-to-spec mapping) |
+| `crates/mega-evm/src/` (new/renamed modules) | `AGENTS.md` (Core Source Layout section) |
+| `crates/system-contracts/contracts/` (new contract) | `AGENTS.md` (System Contracts table) |
+| `crates/mega-evm/src/constants.rs` | `AGENTS.md` (Key Concepts sections referencing constant names) |
+| `crates/mega-evm/src/system/` | `AGENTS.md` (System Contracts section), `.claude/skills/doc-impact-check/SKILL.md` and `.claude/skills/doc-freshness/SKILL.md` (code-to-doc mapping tables) |
+| `crates/mega-evm/src/limit/` (new tracker) | `AGENTS.md` (Multidimensional Resource Limits section) |
+| `docs/` (new pages added to SUMMARY.md) | `.claude/skills/doc-impact-check/SKILL.md` and `.claude/skills/doc-freshness/SKILL.md` (code-to-doc mapping tables need new entries) |
+
+## Workflow
+
+### Phase 1: Read the Diff
+
+```bash
+gh pr diff $PR_NUMBER
+```
+
+Identify all changed files and classify each as:
+- **Behavioral code change**: Modifies EVM semantics, gas costs, resource limits, system contract logic, spec definitions.
+- **Test-only change**: Only adds/modifies tests. No doc impact.
+- **Refactoring**: Restructures code without changing behavior. No doc impact.
+- **Doc change**: Already modifies files under `docs/`. Note which pages are updated.
+
+Focus on behavioral code changes only.
+
+### Phase 2: Map Changes to Doc Pages
+
+For each behavioral code change:
+
+1. Use the code-to-doc mapping table above to identify potentially affected pages.
+2. Also check the agent file mapping table — code changes may affect `AGENTS.md`, `CLAUDE.md`, or skill files.
+3. Read the affected source code to understand *what* changed (new constant value? new spec gate? new opcode behavior?).
+4. Read the potentially affected doc and agent files to check if the current content matches the new behavior.
+
+### Phase 3: Check for Existing Doc Updates
+
+Check if the PR already includes changes to the affected doc pages:
+- If the PR updates the relevant doc pages, verify the updates are consistent with the code changes.
+- If the PR does NOT update the relevant doc pages, flag them.
+
+### Phase 4: Report
+
+Post a single PR comment with findings.
+
+**If doc or agent file updates are needed:**
+
+```markdown
+## Documentation Impact
+
+This PR modifies EVM behavior that is documented in `docs/` or referenced in agent files. The following files may need updating:
+
+### Spec Documentation
+
+| Doc page | Reason |
+|----------|--------|
+| `docs/evm/dual-gas-model.md` | {what changed and why the page is affected} |
+| `docs/evm/resource-limits.md` | {what changed and why the page is affected} |
+
+{If the PR introduces a new spec}: A new upgrade page under `docs/upgrades/` is also needed.
+
+### Agent / Skill Files
+
+| File | Reason |
+|------|--------|
+| `AGENTS.md` | {e.g., spec progression list needs new spec, system contract table needs new entry} |
+
+These updates can be included in this PR or in a follow-up.
+```
+
+**If no doc updates are needed:**
+
+Do NOT post a comment.
+Only comment when there is an actionable finding.
+
+**If the PR already includes correct doc updates:**
+
+Do NOT post a comment.
+The PR review job handles general review.
+
+## Rules
+
+- Only flag genuine behavioral changes that affect documented behavior.
+  Do NOT flag refactorings, test additions, or internal restructuring.
+- Be specific about *what* in the docs needs updating.
+  "This page may need updating" is not actionable.
+  "`COMPUTE_GAS_LIMIT` changed from 1,000,000,000 to 2,000,000,000 — update the Constants table in `docs/evm/resource-limits.md`" is actionable.
+- Respect the spec's backward compatibility rule: if the change introduces a new spec, note that a new upgrade page is needed under `docs/upgrades/`.
+- Do NOT edit documentation yourself. This skill produces a comment, not edits.
+- Do NOT duplicate the work of the `pr-review` job. Focus exclusively on doc impact.
+- If uncertain whether a change is behavioral, err on the side of flagging it — a false positive is better than a missed doc gap.

--- a/.claude/skills/doc-readability/SKILL.md
+++ b/.claude/skills/doc-readability/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: doc-readability
+description: Evaluates documentation readability, structure, and compliance with docs/AGENTS.md conventions. Use when reviewing doc quality, auditing formatting compliance, checking a page before publishing, or running a readability audit across the specification.
+---
+
+# Documentation Readability Evaluation
+
+Evaluate readability and spec-layer compliance for: $ARGUMENTS
+
+Parse the arguments to determine scope.
+Accepted inputs:
+
+- A single page path (e.g., `docs/evm/dual-gas-model.md`) — evaluate that page.
+- A directory (e.g., `docs/evm/`) — evaluate all pages in that directory.
+- `all` — evaluate every page listed in `docs/SUMMARY.md`.
+
+Default (no arguments): evaluate all pages.
+
+## Setup
+
+Before evaluating any page:
+
+1. Read `docs/AGENTS.md` — the authoritative writing rules for this specification.
+2. Read `docs/SUMMARY.md` — the full page inventory.
+
+## Evaluation Checklist
+
+### 1. Structural Lint
+
+- [ ] **Frontmatter**: YAML frontmatter present with a `spec` field (concept pages) or `description` field (upgrade pages).
+- [ ] **Heading hierarchy**: Exactly one H1 (`#`). Sections use H2 (`##`), subsections H3 (`###`). No heading level skips.
+- [ ] **One sentence per line**: Each sentence on its own line for diff readability. Flag paragraphs where multiple sentences share a line.
+- [ ] **Page in SUMMARY.md**: The page appears in `docs/SUMMARY.md`. Flag orphaned pages.
+
+### 2. Page Structure Compliance
+
+Concept pages MUST follow this section order (per `docs/AGENTS.md`):
+
+```
+# Page Title
+Abstract
+## Motivation
+## Specification
+## Constants
+## Rationale
+## Security Considerations
+## Spec History
+```
+
+- [ ] **Required sections present**: For pages defining behavioral rules, check that Specification and Constants sections exist.
+- [ ] **Section order**: Sections appear in the prescribed order.
+- [ ] **Upgrade page structure**: Upgrade pages under `upgrades/` follow the required structure (Summary, What Changed with Previous/New behavior, Developer Impact, Safety and Compatibility, References).
+
+### 3. Normative Language
+
+- [ ] **MUST/SHALL/SHOULD/MAY usage**: Behavioral rules in Specification sections use uppercase normative keywords per RFC 2119.
+- [ ] **No normative keywords outside Specification/Security**: Motivation, Rationale, and Spec History use plain English only.
+- [ ] **No implementation details**: Specification sections do not reference code patterns, function names, or implementation strategies.
+- [ ] **No developer guidance**: No "tips", "best practices", "how to use", or "you should" language.
+- [ ] **No user-facing language**: No second-person ("you") in Specification sections.
+
+### 4. Constants and Formulas
+
+- [ ] **Named constants**: Every numeric value in the Specification is defined as a named constant in the Constants table.
+- [ ] **No magic numbers**: Formulas reference constant names, not embedded numeric values.
+- [ ] **Constant rows complete**: Each constant row has name, value, and one-line description.
+
+### 5. Spec Versioning
+
+- [ ] **Latest spec implicit**: Main content does not mention the latest spec name in Specification, Constants, or Motivation sections.
+- [ ] **Unstable content in `<details>`**: Unstable (not-yet-activated) spec content is wrapped in `<details>` blocks.
+- [ ] **Spec History format**: Overview pages use simple lists; concept pages may use tables. Only list specs that changed relevant behavior.
+
+### 6. Cross-Linking
+
+- [ ] **Glossary first-use linking**: First mention of MegaETH-specific terms links to glossary entry. No over-linking.
+- [ ] **Spec names link to upgrade pages**: When a spec is mentioned by name, it links to `upgrades/{spec}.md`.
+- [ ] **Anchor targets are headings**: Any `#fragment` link target is a markdown heading, not bold text.
+- [ ] **No external user/dev links**: Spec pages do not link to external user docs or developer docs.
+
+### 7. Formatting
+
+- [ ] **Tables for structured data**: Gas costs, opcode lists, resource limits, constants use tables.
+- [ ] **Unambiguous table values**: "Unlimited", "No limit", or "N/A" instead of bare dashes.
+- [ ] **Hint blocks**: `{% hint style="info" %}` used sparingly for non-normative notes. No `{% hint style="success" %}`. `{% hint style="danger" %}` only for deprecation notices.
+
+## Output Format
+
+```markdown
+## Readability
+
+**Scope**: {what was evaluated}
+**Pages evaluated**: {count}
+
+### Summary
+
+| Result | Count |
+|--------|-------|
+| Pass | N |
+| Fail | N |
+| Total findings | N |
+
+### Per-Category Results
+
+For each page, report pass/fail per checklist category.
+Categories with no findings still appear as "Pass" — do not silently omit them.
+
+| Category | Result | Findings |
+|----------|--------|----------|
+| Structural Lint | Pass / Fail | N |
+| Page Structure Compliance | Pass / Fail | N |
+| Normative Language | Pass / Fail | N |
+| Constants and Formulas | Pass / Fail | N |
+| Spec Versioning | Pass / Fail | N |
+| Cross-Linking | Pass / Fail | N |
+| Formatting | Pass / Fail | N |
+
+### Findings
+
+#### R-001: {short description}
+
+- **Severity**: Blocker | Major | Minor
+- **Page**: {path}
+- **Rule**: {which check failed}
+- **Evidence**: {excerpt or description}
+- **Suggested fix**: {concrete edit}
+
+#### R-002: ...
+```
+
+**Severity definitions**:
+
+- **Blocker**: Content violates core spec conventions — implementation details in Specification section, normative keywords in Rationale, spec linking to external user/dev docs.
+- **Major**: Missing frontmatter, heading hierarchy violations, wrong hint block style, missing required sections.
+- **Minor**: Multi-sentence lines, missing glossary links, suboptimal block usage, minor formatting drift.
+
+## Rules
+
+- Evaluate against the `docs/AGENTS.md` rules as written. Do not invent additional style rules.
+- When a page has zero findings, still count it as "Pass" in the summary.
+- Sort findings by severity (Blocker first), then by page.
+- Do NOT fix the issues yourself unless the user explicitly asks. This skill produces a report, not edits.
+- If a finding is ambiguous (could be intentional), note it as Minor with "Review: may be intentional".

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -84,6 +84,12 @@ jobs:
 
             Review this pull request following the guidelines in CLAUDE.md and REVIEW.md.
 
+            ## Documentation scope exclusion
+
+            Do NOT check whether documentation under `docs/` needs updating based on the code changes.
+            A separate `doc-impact` job handles documentation impact analysis.
+            You may still review changes to doc files if they are part of the PR diff, but do not proactively suggest doc updates for code changes.
+
             ## Conversation awareness
 
             Before posting any feedback:
@@ -103,6 +109,67 @@ jobs:
 
             Use `gh pr comment` for top-level feedback (exactly one comment).
             Use `mcp__github_inline_comment__create_inline_comment` (with `confirmed: true`) to highlight specific code issues.
+
+  doc-impact:
+    if: |
+      github.event_name == 'pull_request' &&
+      (github.event.action == 'opened' ||
+       github.event.action == 'synchronize' ||
+       github.event.action == 'ready_for_review' ||
+       github.event.action == 'reopened')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 1
+
+      - name: Check for source code changes
+        id: filter
+        run: |
+          FILES=$(gh pr diff ${{ github.event.pull_request.number }} --name-only || true)
+          if echo "$FILES" | grep -qE '^crates/mega-evm/src/|^crates/system-contracts/'; then
+            echo "has_source_changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_source_changes=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - uses: anthropics/claude-code-action@v1
+        if: steps.filter.outputs.has_source_changes == 'true'
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh api:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(ls:*),Bash(tree:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            You are a documentation impact checker for the MegaETH specification.
+            Your ONLY job is to determine if this PR's code changes require updates to docs/ or agent files (AGENTS.md, CLAUDE.md, docs/AGENTS.md, REVIEW.md, .claude/skills/*/SKILL.md).
+
+            Follow the doc-impact-check skill instructions in .claude/skills/doc-impact-check/SKILL.md.
+
+            Key rules:
+            - Read the PR diff using `gh pr diff`.
+            - Only analyze behavioral code changes (skip tests, CI, refactoring).
+            - Map code changes to affected doc pages AND agent files using both mapping tables (spec docs and agent/skill files).
+            - Check if the PR already includes updates for the affected files.
+            - If updates are needed and missing, post exactly ONE comment via `gh pr comment`.
+            - If no updates are needed, or the PR already includes them, do NOT post any comment.
+            - Do NOT review code quality — the pr-review job handles that.
+
+            Before commenting, check existing PR comments using `gh pr view --comments`.
+            If you already posted a doc-impact comment on this PR:
+            - If the doc updates have been addressed, delete your previous comment using `gh api`.
+            - If there are still gaps but they changed, edit your existing comment.
+            - Do NOT post duplicate comments.
 
   label-check:
     if: |

--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -1,0 +1,112 @@
+name: Documentation Audit
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9:00 UTC
+  workflow_dispatch:
+    inputs:
+      freshness_window:
+        description: "Time window for freshness check (e.g., 7d, 14d, 30d)"
+        required: false
+        default: "14d"
+
+jobs:
+  audit:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      issues: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --allowedTools "Read,Glob,Grep,Bash(gh issue list:*),Bash(gh issue create:*),Bash(gh issue view:*),Bash(gh issue edit:*),Bash(gh issue close:*),Bash(gh pr list:*),Bash(gh pr view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git blame:*),Bash(ls:*),Bash(tree:*)"
+          prompt: |
+            REPO: ${{ github.repository }}
+            FRESHNESS_WINDOW: ${{ github.event.inputs.freshness_window || '14d' }}
+
+            You are a documentation auditor for the MegaETH specification.
+            Your scope includes docs/ AND agent instruction files (AGENTS.md, CLAUDE.md, docs/AGENTS.md, REVIEW.md, .claude/skills/*/SKILL.md).
+            Agent files contain code paths, spec progressions, system contract tables, and other references that can go stale.
+            Run all three audit dimensions and file a single GitHub issue with findings.
+
+            ## Step 1: Check for existing audit issue
+
+            Search for an existing open issue with both `agent` and `comp:doc` labels:
+            ```
+            gh issue list --label "agent" --label "comp:doc" --state open --json number,title,url
+            ```
+            If an open audit issue already exists, you will UPDATE it instead of creating a new one.
+
+            ## Step 2: Run freshness check
+
+            Follow the doc-freshness skill in .claude/skills/doc-freshness/SKILL.md.
+            Use the FRESHNESS_WINDOW as the time window.
+            Produce the Freshness section of the report.
+
+            ## Step 3: Run correctness check
+
+            Follow the doc-correctness skill in .claude/skills/doc-correctness/SKILL.md.
+            Scope: all pages in docs/SUMMARY.md PLUS all agent files (AGENTS.md, CLAUDE.md, docs/AGENTS.md, REVIEW.md, .claude/skills/*/SKILL.md).
+            For agent files, verify code-related claims: spec progression lists, system contract tables, source layout descriptions, code path references, unstable spec markers, code-to-doc mapping tables in skills.
+            Produce the Correctness section of the report.
+
+            ## Step 4: Run readability check
+
+            Follow the doc-readability skill in .claude/skills/doc-readability/SKILL.md.
+            Scope: all pages in docs/SUMMARY.md (agent files are excluded from readability checks — they follow their own conventions).
+            Produce the Readability section of the report.
+
+            ## Step 5: File or update issue
+
+            Combine all three sections into a single issue body with this format:
+
+            ```
+            Title: Documentation audit — YYYY-MM-DD
+
+            # Documentation Audit Report
+
+            Automated audit of `docs/` against source code and writing conventions.
+
+            ## Summary
+
+            | Dimension    | Findings |
+            |-------------|----------|
+            | Freshness   | N gaps   |
+            | Correctness | N issues |
+            | Readability | N issues |
+
+            ---
+
+            {Freshness section from Step 2}
+
+            ---
+
+            {Correctness section from Step 3}
+
+            ---
+
+            {Readability section from Step 4}
+            ```
+
+            If no existing open issue was found in Step 1:
+            - Create a new issue: `gh issue create --title "Documentation audit — $(date +%Y-%m-%d)" --label "agent" --label "comp:doc" --body "..."`
+
+            If an existing open issue was found in Step 1:
+            - Update the existing issue body: `gh issue edit {number} --body "..."`
+            - Update the title to reflect the new date: `gh issue edit {number} --title "Documentation audit — $(date +%Y-%m-%d)"`
+
+            ## Rules
+
+            - If ALL three dimensions have zero findings, do NOT create an issue. Close any existing open audit issue with a comment noting "All clear — no findings."
+            - Be thorough but not noisy. Only report genuine issues, not theoretical concerns.
+            - Include source file paths and line numbers for correctness findings.
+            - Include PR URLs for freshness findings.
+            - Each finding must be actionable — explain what needs to change, not just what's wrong.


### PR DESCRIPTION
## Summary

Add two agent-based CI mechanisms to keep documentation in sync with code changes:

1. **PR-triggered doc impact check** (`doc-impact` job in `claude.yml`) — When a PR modifies source code under `crates/mega-evm/src/` or `crates/system-contracts/`, an agent analyzes the diff and comments if documentation under `docs/` or agent files (`AGENTS.md`, `CLAUDE.md`, skill files) need updating. Non-blocking.

2. **Scheduled weekly doc audit** (`doc-audit.yml`) — Runs every Monday (+ manual trigger) with three audit dimensions:
   - **Freshness**: Scans merged PRs for undocumented behavioral changes
   - **Correctness**: Verifies constants, spec attributions, and claims against source code
   - **Readability**: Checks compliance with `docs/AGENTS.md` writing conventions

   Files a single GitHub issue with `agent` + `comp:doc` labels. Updates existing open issue if one exists.

### Skills added

| Skill | Purpose |
|-------|---------|
| `doc-impact-check` | PR diff → doc/agent file impact analysis with code-to-doc mapping |
| `doc-freshness` | Merged PR scanning → coverage gap report |
| `doc-correctness` | Claim extraction → source code verification |
| `doc-readability` | Structure/tone compliance against docs/AGENTS.md |

All skills cover both `docs/` spec pages and agent instruction files (AGENTS.md, CLAUDE.md, skill files) that contain code-related content.

### Other changes

- `pr-review` job prompt updated to skip doc impact checking (handled by the new dedicated job)