### PR TITLE
feat: introduce REX5 spec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,13 +53,13 @@ Git submodules are required — clone with `--recursive` or run `git submodule u
 
 ### Spec System (`MegaSpecId`)
 
-Progression: `EQUIVALENCE` → `MINI_REX` → `REX` → `REX1` → `REX2` → `REX3` → `REX4`
+Progression: `EQUIVALENCE` → `MINI_REX` → `REX` → `REX1` → `REX2` → `REX3` → `REX4` → `REX5`
 
 - **Spec** defines EVM behavior (what the EVM does).
   Defined in `crates/mega-evm/src/evm/spec.rs`.
   The code base **MUST** maintain **backward-compatibility**, which means the semantics (i.e., EVM behaviors) must remain the same for existing specs.
   The only exception for this is the **unstable** spec that is under active development (if exists, must be the latest one).
-  - _At present, all specs are stable. There is no unstable spec._
+  - _`REX5` is the current unstable spec under active development._
     When a new spec is introduced, this line should be updated to indicate the unstable spec.
   - Specifications of each spec can be found in the upgrade pages under `docs/spec/upgrades/`.
 - **Hardfork** (`MegaHardfork`) defines network upgrade events (when specs activate).

--- a/bin/mega-evme/src/common/env.rs
+++ b/bin/mega-evme/src/common/env.rs
@@ -28,8 +28,8 @@ use super::{EvmeError, Result};
 #[command(next_help_heading = "Chain Options")]
 pub struct ChainArgs {
     /// Name of spec to use, possible values: `MiniRex`, `Equivalence`, `Rex`, `Rex1`, `Rex2`,
-    /// `Rex3`, `Rex4`
-    #[arg(long = "spec", default_value = "Rex4")]
+    /// `Rex3`, `Rex4`, `Rex5`
+    #[arg(long = "spec", default_value = "Rex5")]
     pub spec: String,
 
     /// `ChainID` to use

--- a/bin/mega-evme/src/replay/hardforks.rs
+++ b/bin/mega-evme/src/replay/hardforks.rs
@@ -12,7 +12,8 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766147599))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770116400))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771380000))
-            .with(MegaHardfork::Rex4, ForkCondition::Never),
+            .with(MegaHardfork::Rex4, ForkCondition::Never)
+            .with(MegaHardfork::Rex5, ForkCondition::Never),
         // MegaETH mainnet
         4326 => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
@@ -22,7 +23,8 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766282400))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770246000))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771639200))
-            .with(MegaHardfork::Rex4, ForkCondition::Never),
+            .with(MegaHardfork::Rex4, ForkCondition::Never)
+            .with(MegaHardfork::Rex5, ForkCondition::Never),
         // Default: all hardforks enabled at genesis
         _ => MegaHardforkConfig::new()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(0))
@@ -32,6 +34,7 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(0))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(0))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(0))
-            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(0)),
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(0))
+            .with(MegaHardfork::Rex5, ForkCondition::Timestamp(0)),
     }
 }

--- a/bin/mega-evme/src/replay/hardforks.rs
+++ b/bin/mega-evme/src/replay/hardforks.rs
@@ -12,7 +12,7 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766147599))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770116400))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771380000))
-            .with(MegaHardfork::Rex4, ForkCondition::Never)
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(1776400000))
             .with(MegaHardfork::Rex5, ForkCondition::Never),
         // MegaETH mainnet
         4326 => MegaHardforkConfig::new()
@@ -23,7 +23,7 @@ pub fn get_hardfork_config(chain_id: u64) -> MegaHardforkConfig {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(1766282400))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(1770246000))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771639200))
-            .with(MegaHardfork::Rex4, ForkCondition::Never)
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(1776659200))
             .with(MegaHardfork::Rex5, ForkCondition::Never),
         // Default: all hardforks enabled at genesis
         _ => MegaHardforkConfig::new()

--- a/crates/mega-evm/src/block/hardfork.rs
+++ b/crates/mega-evm/src/block/hardfork.rs
@@ -30,6 +30,8 @@ hardfork! {
         Rex3,
         /// The eighth hardfork (fourth patch to Rex).
         Rex4,
+        /// The ninth hardfork (fifth patch to Rex).
+        Rex5,
     }
 }
 
@@ -48,6 +50,7 @@ impl MegaHardfork {
             Self::Rex2 => MegaSpecId::REX2,
             Self::Rex3 => MegaSpecId::REX3,
             Self::Rex4 => MegaSpecId::REX4,
+            Self::Rex5 => MegaSpecId::REX5,
         }
     }
 }
@@ -80,7 +83,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the latest `MegaHardfork` that is active at the given timestamp. If no `MegaHardfork`
     /// is active at the given timestamp, returns `None`.
     fn hardfork(&self, timestamp: u64) -> Option<MegaHardfork> {
-        if self.is_rex_4_active_at_timestamp(timestamp) {
+        if self.is_rex_5_active_at_timestamp(timestamp) {
+            Some(MegaHardfork::Rex5)
+        } else if self.is_rex_4_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex4)
         } else if self.is_rex_3_active_at_timestamp(timestamp) {
             Some(MegaHardfork::Rex3)
@@ -104,7 +109,9 @@ pub trait MegaHardforks: OpHardforks {
     /// Gets the expected `MegaSpecId` for a block with the given timestamp.
     fn spec_id(&self, timestamp: BlockTimestamp) -> MegaSpecId {
         // Newer hardforks should be checked first
-        if self.is_rex_4_active_at_timestamp(timestamp) {
+        if self.is_rex_5_active_at_timestamp(timestamp) {
+            MegaSpecId::REX5
+        } else if self.is_rex_4_active_at_timestamp(timestamp) {
             MegaSpecId::REX4
         } else if self.is_rex_3_active_at_timestamp(timestamp) {
             MegaSpecId::REX3
@@ -163,6 +170,11 @@ pub trait MegaHardforks: OpHardforks {
     /// Returns `true` if [`MegaHardfork::Rex4`] is active at given block timestamp.
     fn is_rex_4_active_at_timestamp(&self, timestamp: u64) -> bool {
         self.mega_fork_activation(MegaHardfork::Rex4).active_at_timestamp(timestamp)
+    }
+
+    /// Returns `true` if [`MegaHardfork::Rex5`] is active at given block timestamp.
+    fn is_rex_5_active_at_timestamp(&self, timestamp: u64) -> bool {
+        self.mega_fork_activation(MegaHardfork::Rex5).active_at_timestamp(timestamp)
     }
 }
 
@@ -241,6 +253,7 @@ impl MegaHardforkConfig {
         self.insert(MegaHardfork::Rex2, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex3, ForkCondition::Timestamp(0));
         self.insert(MegaHardfork::Rex4, ForkCondition::Timestamp(0));
+        self.insert(MegaHardfork::Rex5, ForkCondition::Timestamp(0));
         self
     }
 
@@ -320,6 +333,7 @@ mod tests {
             (MegaHardfork::Rex2, MegaSpecId::REX2),
             (MegaHardfork::Rex3, MegaSpecId::REX3),
             (MegaHardfork::Rex4, MegaSpecId::REX4),
+            (MegaHardfork::Rex5, MegaSpecId::REX5),
         ];
 
         for (hardfork, expected_spec) in cases {
@@ -382,6 +396,7 @@ mod tests {
             MegaHardfork::Rex2,
             MegaHardfork::Rex3,
             MegaHardfork::Rex4,
+            MegaHardfork::Rex5,
         ] {
             assert_eq!(config.mega_fork_activation(hardfork), ForkCondition::Timestamp(0));
         }
@@ -397,7 +412,8 @@ mod tests {
             .with(MegaHardfork::Rex1, ForkCondition::Timestamp(50))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(60))
             .with(MegaHardfork::Rex3, ForkCondition::Timestamp(70))
-            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(80));
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(80))
+            .with(MegaHardfork::Rex5, ForkCondition::Timestamp(90));
 
         let expected = [
             (0, None, MegaSpecId::EQUIVALENCE),
@@ -409,6 +425,7 @@ mod tests {
             (65, Some(MegaHardfork::Rex2), MegaSpecId::REX2),
             (75, Some(MegaHardfork::Rex3), MegaSpecId::REX3),
             (85, Some(MegaHardfork::Rex4), MegaSpecId::REX4),
+            (95, Some(MegaHardfork::Rex5), MegaSpecId::REX5),
         ];
 
         for (timestamp, expected_hardfork, expected_spec) in expected {
@@ -432,13 +449,16 @@ mod tests {
     fn test_spec_id_with_gaps_in_hardfork_configuration() {
         let config = MegaHardforkConfig::default()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(10))
-            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(20));
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(20))
+            .with(MegaHardfork::Rex5, ForkCondition::Timestamp(30));
 
         assert_eq!(config.spec_id(5), MegaSpecId::EQUIVALENCE);
         assert_eq!(config.spec_id(15), MegaSpecId::MINI_REX);
         assert_eq!(config.spec_id(25), MegaSpecId::REX4);
+        assert_eq!(config.spec_id(35), MegaSpecId::REX5);
         assert_eq!(config.hardfork(15), Some(MegaHardfork::MiniRex));
         assert_eq!(config.hardfork(25), Some(MegaHardfork::Rex4));
+        assert_eq!(config.hardfork(35), Some(MegaHardfork::Rex5));
     }
 
     #[test]
@@ -446,10 +466,11 @@ mod tests {
         let config = MegaHardforkConfig::default()
             .with(MegaHardfork::MiniRex, ForkCondition::Timestamp(10))
             .with(MegaHardfork::Rex2, ForkCondition::Timestamp(10))
-            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(10));
+            .with(MegaHardfork::Rex4, ForkCondition::Timestamp(10))
+            .with(MegaHardfork::Rex5, ForkCondition::Timestamp(10));
 
         assert_eq!(config.hardfork(9), None);
-        assert_eq!(config.hardfork(10), Some(MegaHardfork::Rex4));
-        assert_eq!(config.spec_id(10), MegaSpecId::REX4);
+        assert_eq!(config.hardfork(10), Some(MegaHardfork::Rex5));
+        assert_eq!(config.spec_id(10), MegaSpecId::REX5);
     }
 }

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -392,7 +392,8 @@ impl BlockLimits {
             MegaHardfork::Rex1 |
             MegaHardfork::Rex2 |
             MegaHardfork::Rex3 |
-            MegaHardfork::Rex4 => Self {
+            MegaHardfork::Rex4 |
+            MegaHardfork::Rex5 => Self {
                 block_txs_data_limit: crate::constants::mini_rex::BLOCK_DATA_LIMIT,
                 block_kv_update_limit: crate::constants::mini_rex::BLOCK_KV_UPDATE_LIMIT,
                 block_state_growth_limit: crate::constants::rex::BLOCK_STATE_GROWTH_LIMIT,

--- a/crates/mega-evm/src/constants.rs
+++ b/crates/mega-evm/src/constants.rs
@@ -130,6 +130,9 @@ pub mod rex4 {
     pub const STORAGE_CALL_STIPEND: u64 = 23_000;
 }
 
+/// Constants for the `REX5` spec.
+pub mod rex5 {}
+
 /// Constants for the `REX` spec.
 pub mod rex {
     /// Additional storage gas cost added to transaction intrinsic gas for the `REX` spec.

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -182,6 +182,10 @@ impl<DB: Database, ExtEnvs: ExternalEnvTypes> MegaInstructions<DB, ExtEnvs> {
                 EthInterpreter,
                 MegaContext<DB, ExtEnvs>,
             >()),
+            MegaSpecId::REX5 => EthInstructions::new(rex5::instruction_table::<
+                EthInterpreter,
+                MegaContext<DB, ExtEnvs>,
+            >()),
         };
         Self { spec, inner: instruction_table }
     }
@@ -319,6 +323,23 @@ mod rex4 {
         table[SELFBALANCE as usize] = volatile_data_ext::selfbalance;
 
         table
+    }
+}
+
+mod rex5 {
+    use super::*;
+
+    /// Returns the instruction table for the `REX5` spec.
+    ///
+    /// Changes from Rex4: none yet.
+    pub(super) const fn instruction_table<
+        WIRE: InterpreterTypes<Stack: StackInspectTr>,
+        H: HostExt + ContextTr + JournalInspectTr + ?Sized,
+    >() -> [Instruction<WIRE, H>; 256]
+    where
+        WIRE::Stack: StackInspectTr,
+    {
+        rex4::instruction_table::<WIRE, H>()
     }
 }
 

--- a/crates/mega-evm/src/evm/limit.rs
+++ b/crates/mega-evm/src/evm/limit.rs
@@ -27,6 +27,7 @@ impl EvmTxRuntimeLimits {
             MegaSpecId::REX | MegaSpecId::REX1 | MegaSpecId::REX2 => Self::rex(),
             MegaSpecId::REX3 => Self::rex3(),
             MegaSpecId::REX4 => Self::rex4(),
+            MegaSpecId::REX5 => Self::rex5(),
         }
     }
 
@@ -87,6 +88,13 @@ impl EvmTxRuntimeLimits {
     /// Per-frame state growth budgets are handled by `FrameLimitTracker`.
     fn rex4() -> Self {
         Self::rex3()
+    }
+
+    /// Limits for the `REX5` spec.
+    ///
+    /// Currently identical to Rex4 limits.
+    fn rex5() -> Self {
+        Self::rex4()
     }
 }
 

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -45,7 +45,8 @@ impl MegaPrecompiles {
             MegaSpecId::REX1 |
             MegaSpecId::REX2 |
             MegaSpecId::REX3 |
-            MegaSpecId::REX4 => rex(),
+            MegaSpecId::REX4 |
+            MegaSpecId::REX5 => rex(),
         };
 
         Self { inner: EthPrecompiles { precompiles: inner, spec: spec.into_eth_spec() }, spec }

--- a/crates/mega-evm/src/evm/spec.rs
+++ b/crates/mega-evm/src/evm/spec.rs
@@ -21,6 +21,7 @@ use serde::{Deserialize, Serialize};
 /// - [`SpecId::REX2`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX3`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 /// - [`SpecId::REX4`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
+/// - [`SpecId::REX5`] -> [`OpSpecId::ISTHMUS`] -> [`EthSpecId::PRAGUE`]
 #[repr(u8)]
 #[derive(
     Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize,
@@ -42,8 +43,10 @@ pub enum MegaSpecId {
     /// The EVM version for the *Rex3* hardfork of `MegaETH`.
     REX3,
     /// The EVM version for the *Rex4* hardfork of `MegaETH`.
-    #[default]
     REX4,
+    /// The EVM version for the *Rex5* hardfork of `MegaETH`.
+    #[default]
+    REX5,
 }
 
 /// String identifiers for `MegaETH` EVM versions.
@@ -63,6 +66,8 @@ pub mod name {
     pub const REX3: &str = "Rex3";
     /// The string identifier for the *Rex4* version of the `MegaETH` EVM.
     pub const REX4: &str = "Rex4";
+    /// The string identifier for the *Rex5* version of the `MegaETH` EVM.
+    pub const REX5: &str = "Rex5";
 }
 
 impl MegaSpecId {
@@ -80,7 +85,8 @@ impl MegaSpecId {
             Self::REX1 |
             Self::REX2 |
             Self::REX3 |
-            Self::REX4 => OpSpecId::ISTHMUS,
+            Self::REX4 |
+            Self::REX5 => OpSpecId::ISTHMUS,
         }
     }
 
@@ -104,6 +110,7 @@ impl From<MegaSpecId> for &'static str {
             MegaSpecId::REX2 => name::REX2,
             MegaSpecId::REX3 => name::REX3,
             MegaSpecId::REX4 => name::REX4,
+            MegaSpecId::REX5 => name::REX5,
         }
     }
 }
@@ -121,6 +128,7 @@ impl FromStr for MegaSpecId {
             name::REX2 => Ok(Self::REX2),
             name::REX3 => Ok(Self::REX3),
             name::REX4 => Ok(Self::REX4),
+            name::REX5 => Ok(Self::REX5),
             _ => Err(UnknownHardfork),
         }
     }
@@ -151,7 +159,7 @@ impl Display for MegaSpecId {
 mod tests {
     use super::*;
 
-    const ALL_SPECS: [(MegaSpecId, &str); 7] = [
+    const ALL_SPECS: [(MegaSpecId, &str); 8] = [
         (MegaSpecId::EQUIVALENCE, name::EQUIVALENCE),
         (MegaSpecId::MINI_REX, name::MINI_REX),
         (MegaSpecId::REX, name::REX),
@@ -159,6 +167,7 @@ mod tests {
         (MegaSpecId::REX2, name::REX2),
         (MegaSpecId::REX3, name::REX3),
         (MegaSpecId::REX4, name::REX4),
+        (MegaSpecId::REX5, name::REX5),
     ];
 
     #[test]
@@ -169,7 +178,7 @@ mod tests {
             assert_eq!(spec.to_string(), expected_name);
         }
 
-        assert_eq!(MegaSpecId::default(), MegaSpecId::REX4);
+        assert_eq!(MegaSpecId::default(), MegaSpecId::REX5);
         assert_eq!(MegaSpecId::from_str("unknown"), Err(UnknownHardfork));
     }
 
@@ -189,9 +198,12 @@ mod tests {
         assert!(MegaSpecId::REX4.is_enabled(MegaSpecId::EQUIVALENCE));
         assert!(MegaSpecId::MINI_REX.is_enabled(MegaSpecId::EQUIVALENCE));
         assert!(MegaSpecId::REX2.is_enabled(MegaSpecId::REX1));
+        assert!(MegaSpecId::REX5.is_enabled(MegaSpecId::REX4));
+        assert!(MegaSpecId::REX5.is_enabled(MegaSpecId::EQUIVALENCE));
 
         assert!(!MegaSpecId::EQUIVALENCE.is_enabled(MegaSpecId::MINI_REX));
         assert!(!MegaSpecId::REX1.is_enabled(MegaSpecId::REX2));
         assert!(!MegaSpecId::REX3.is_enabled(MegaSpecId::REX4));
+        assert!(!MegaSpecId::REX4.is_enabled(MegaSpecId::REX5));
     }
 }


### PR DESCRIPTION
  ## Summary

  - Add the REX5 spec and Rex5 hardfork.
  - Rex5 is currently identical to Rex4 (same instructions, precompiles, limits, constants).
  - Rex5 is marked as the unstable spec under active development.

## Test plan

- `cargo fmt --all --check` - passed
- `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked` - passed

## Docs

- REX5 is just introduced as an empty unstable spec in this PR — it's identical to Rex4 with no behavioral changes yet.
- The actual feature work will land in follow-up PRs on top of this.
- **Documentation updates will come together with those feature PRs once the spec semantics are defined.**
