### PR TITLE
fix: clarify access control staticcall behavior

### DIFF
--- a/crates/mega-evm/src/block/executor.rs
+++ b/crates/mega-evm/src/block/executor.rs
@@ -114,7 +114,7 @@ where
         }
         assert!(
             hardforks.is_regolith_active_at_timestamp(block_timestamp),
-            "mega-evm assumes Regolith hardfork is not active"
+            "mega-evm assumes Regolith hardfork is always active"
         );
         assert!(
             hardforks.is_canyon_active_at_timestamp(block_timestamp),

--- a/crates/mega-evm/tests/rex4/access_control.rs
+++ b/crates/mega-evm/tests/rex4/access_control.rs
@@ -166,6 +166,23 @@ fn append_staticcall(builder: BytecodeBuilder, target: Address, gas: u64) -> Byt
         .append(STATICCALL)
 }
 
+/// Builds bytecode that STATICCALLs the access control contract with the given selector.
+fn append_access_control_staticcall(
+    builder: BytecodeBuilder,
+    selector: [u8; 4],
+    gas: u64,
+) -> BytecodeBuilder {
+    let builder = builder.mstore(0x0, selector);
+    builder
+        .push_number(0_u64) // retSize
+        .push_number(0_u64) // retOffset
+        .push_number(4_u64) // argsSize
+        .push_number(0_u64) // argsOffset
+        .push_address(ACCESS_CONTROL_ADDRESS)
+        .push_number(gas)
+        .append(STATICCALL)
+}
+
 /// Builds bytecode that DELEGATECALLs a target address with the given gas.
 fn append_delegatecall(builder: BytecodeBuilder, target: Address, gas: u64) -> BytecodeBuilder {
     builder
@@ -805,6 +822,57 @@ fn test_enable_when_not_disabled_is_noop() {
         result.result.is_success(),
         "enableVolatileDataAccess() when not disabled should succeed"
     );
+}
+
+/// STATICCALL to `disableVolatileDataAccess()` should apply the same restriction as CALL.
+#[test]
+fn test_staticcall_disable_volatile_data_access_is_intercepted() {
+    let child_code = BytecodeBuilder::default().append(TIMESTAMP).append(POP).stop().build();
+
+    let parent_code = append_access_control_staticcall(
+        BytecodeBuilder::default(),
+        DISABLE_VOLATILE_DATA_ACCESS_SELECTOR,
+        100_000,
+    );
+    let parent_code = append_log_call_status(parent_code);
+    let parent_code = append_call(parent_code, CHILD, 50_000_000);
+    let parent_code = append_log_call_status(parent_code).stop().build();
+
+    let mut db = MemoryDatabase::default()
+        .account_balance(CALLER, U256::from(1_000_000))
+        .account_code(PARENT, parent_code)
+        .account_code(CHILD, child_code);
+
+    let result = transact(&mut db, default_tx(PARENT)).unwrap();
+    assert!(result.result.is_success(), "Parent tx should succeed");
+    assert_log_call_status(&result, 0, true);
+    assert_log_call_status(&result, 1, false);
+}
+
+/// STATICCALL to `enableVolatileDataAccess()` should re-enable access when the caller disabled it.
+#[test]
+fn test_staticcall_enable_volatile_data_access_is_intercepted() {
+    let child_code = BytecodeBuilder::default().append(TIMESTAMP).append(POP).stop().build();
+
+    let parent_code = call_disable_volatile_data_access(BytecodeBuilder::default());
+    let parent_code = append_access_control_staticcall(
+        parent_code,
+        ENABLE_VOLATILE_DATA_ACCESS_SELECTOR,
+        100_000,
+    );
+    let parent_code = append_log_call_status(parent_code);
+    let parent_code = append_call(parent_code, CHILD, 50_000_000);
+    let parent_code = append_log_call_status(parent_code).stop().build();
+
+    let mut db = MemoryDatabase::default()
+        .account_balance(CALLER, U256::from(1_000_000))
+        .account_code(PARENT, parent_code)
+        .account_code(CHILD, child_code);
+
+    let result = transact(&mut db, default_tx(PARENT)).unwrap();
+    assert!(result.result.is_success(), "Parent tx should succeed");
+    assert_log_call_status(&result, 0, true);
+    assert_log_call_status(&result, 1, true);
 }
 
 // ============================================================================

--- a/docs/spec/system-contracts/mega-access-control.md
+++ b/docs/spec/system-contracts/mega-access-control.md
@@ -81,6 +81,12 @@ They fall through to the on-chain bytecode, which reverts with `NotIntercepted()
 
 Unknown selectors MUST NOT be intercepted and MUST fall through to the on-chain bytecode.
 
+### Execution-Local Policy State
+
+The restriction controlled by `disableVolatileDataAccess` and `enableVolatileDataAccess` MUST be treated as execution-local policy state rather than persistent chain state.
+Successful interception of those selectors MUST update that execution-local policy state identically for `CALL` and `STATICCALL`.
+Those updates MUST NOT write account storage, emit logs, or transfer value.
+
 ### Value Transfer Policy
 
 All intercepted functions MUST reject calls with non-zero value transfer.
@@ -89,6 +95,7 @@ If the call carries a non-zero transferred value, the node MUST revert with `Non
 ### `disableVolatileDataAccess`
 
 When intercepted, the node MUST disable volatile data access for the caller's [call frame](../glossary.md#call-frame) and all descendant call frames.
+The rule above MUST apply identically when the selector is reached through `CALL` or `STATICCALL`.
 
 While disabled, any volatile data access — block environment reads, beneficiary-targeted account access (including `SELFDESTRUCT` to the beneficiary), and [oracle](oracle.md) storage reads — MUST revert immediately with `VolatileDataAccessDisabled(VolatileDataAccessType accessType)`.
 
@@ -97,6 +104,7 @@ Blocked volatile access MUST NOT update volatile-access tracking and MUST NOT ti
 ### `enableVolatileDataAccess`
 
 When intercepted, the node MUST re-enable volatile data access for the caller's call frame and descendant call frames if and only if the restriction was set at the caller's depth or was not active.
+The rule above MUST apply identically when the selector is reached through `CALL` or `STATICCALL`.
 
 If the restriction was set by an ancestor call frame (a parent at a shallower depth), the node MUST revert with `DisabledByParent()`.
 
@@ -130,6 +138,11 @@ Reverting makes the restriction visible and forces the caller to handle it expli
 Allowing untrusted child code to re-enable access would defeat the purpose.
 The calling contract disables access precisely because it does not trust inner calls to behave correctly with volatile data.
 The parent-override rule preserves the caller's intent.
+
+**Why allow `disableVolatileDataAccess()` and `enableVolatileDataAccess()` under `STATICCALL`?**
+These functions change execution-local policy state only.
+Allowing the same interception semantics under `STATICCALL` lets read-only frames defend themselves against descendant volatile accesses and restore their own policy when the disable was set at the same depth.
+Treating these selectors as forbidden mutable side effects under `STATICCALL` would make that defense unavailable to `view` entrypoints.
 
 ## Spec History
 


### PR DESCRIPTION
## Summary

  Clarify `MegaAccessControl` behavior under `STATICCALL` and add direct regression coverage for it.

  This PR also fixes an inverted Regolith assertion message in the block executor so the panic text matches the actual assumption.

  ## Test plan

  - Ran `cargo test -p mega-evm --test rex4 volatile_data_access_is_intercepted`
  - Ran `cargo fmt --all --check`
  - Ran `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked`