### PR TITLE
docs: add Security Considerations to EVM spec pages

### DIFF
--- a/docs/spec/evm/contract-limits.md
+++ b/docs/spec/evm/contract-limits.md
@@ -43,6 +43,10 @@ The initcode limit is defined as:
 MegaETH allows substantially larger contracts than standard Ethereum.
 The enlarged limits support deployment patterns that would otherwise exceed Ethereum's contract-size constraints.
 
+## Security Considerations
+
+This page has no security considerations.
+
 ## Spec History
 
 - [MiniRex](../upgrades/minirex.md) introduced the enlarged contract and initcode limits.

--- a/docs/spec/evm/dual-gas-model.md
+++ b/docs/spec/evm/dual-gas-model.md
@@ -222,6 +222,13 @@ The `STORAGE_GAS_MULTIPLIER` of 10 was chosen to reflect the long-term storage a
 Every transaction imposes a baseline storage cost on nodes regardless of its execution: the transaction itself must be stored, the receipt must be persisted, and account state (nonce, balance) must be updated.
 The 39,000 flat intrinsic storage gas covers this per-transaction overhead.
 
+## Security Considerations
+
+**If storage gas is omitted or undercharged**, MegaETH's 0.001 gwei base fee makes every SSTORE, contract deployment, and LOG call negligible in cost.
+A single transaction could write thousands of storage slots or emit megabytes of log data for nearly zero fee — the exact attack the dual gas model exists to prevent.
+
+**If unused `STORAGE_CALL_STIPEND` is returned to the caller rather than burned**, system-granted gas leaks back to the caller, who can redirect it to non-storage operations — undermining the compute-gas cap designed to keep the stipend storage-only.
+
 ## Spec History
 
 For the historical evolution of storage gas formulas and constants across specs:

--- a/docs/spec/evm/gas-detention.md
+++ b/docs/spec/evm/gas-detention.md
@@ -165,6 +165,13 @@ Allowing a less restrictive later trigger to relax an earlier cap would make det
 The purpose of detention is to bound the remainder of execution after volatile access.
 If the cap were scoped only to the triggering call frame, contracts could evade the limit by returning to a parent frame and continuing computation there.
 
+## Security Considerations
+
+**If detention is call-frame-scoped rather than transaction-scoped**, a contract can trigger volatile access inside a child call frame, revert the frame, and resume unbounded execution in the parent — entirely bypassing detention.
+Transaction-level scoping is essential to preserve the invariant that compute gas after any volatile access is bounded.
+
+**If detention applied in a call frame that later reverts is reversed**, an attacker can trigger volatile access inside a frame it then reverts to escape the detention cap for the rest of the transaction.
+
 ## Spec History
 
 Gas detention semantics evolved across specs:

--- a/docs/spec/evm/gas-forwarding.md
+++ b/docs/spec/evm/gas-forwarding.md
@@ -78,6 +78,11 @@ The inherited 63/64 rule was designed to mitigate call-depth attacks by ensuring
 MegaETH is intended to support block gas limits up to 10 billion gas, which makes the inherited 63/64 reduction insufficient to suppress that attack pattern at deep call depth.
 Retaining 2% instead of approximately 1.56% reduces residual gas more aggressively and restores the protective intent of gas-based call-depth mitigation under MegaETH's higher gas regime.
 
+## Security Considerations
+
+**If more than 98/100 of gas is forwarded**, MegaETH's high block gas limits (up to 10 billion) mean enough residual gas survives at deep call depth to sustain a call-depth denial-of-service attack.
+The 63/64 rule inherited from Ethereum was designed for much lower gas budgets; at 10B gas, 98/100 is needed to achieve the same protective effect.
+
 ## Spec History
 
 - [MiniRex](../upgrades/minirex.md) introduced the 98/100 rule for `CALL`, `CREATE`, and `CREATE2` only.

--- a/docs/spec/evm/precompiles.md
+++ b/docs/spec/evm/precompiles.md
@@ -36,6 +36,10 @@ All other precompiles MUST behave according to the inherited EVM baseline unless
 | ------------------------------- | ------- | ------------------------------------------------------ |
 | `KZG_POINT_EVALUATION_GAS_COST` | 100,000 | Fixed gas cost for the KZG Point Evaluation precompile |
 
+## Security Considerations
+
+This page has no security considerations.
+
 ## Spec History
 
 - [MiniRex](../upgrades/minirex.md) introduced the stable KZG Point Evaluation and ModExp overrides.

--- a/docs/spec/evm/resource-accounting.md
+++ b/docs/spec/evm/resource-accounting.md
@@ -208,6 +208,10 @@ Deduplication prevents artificial inflation of data-size and KV-update counts fr
 During execution, a transaction may first create new state and later remove it.
 Allowing the counter to go negative during intermediate steps keeps the accounting locally composable across nested call frames, while clamping the final reported value prevents negative net state growth from being treated as a meaningful resource credit.
 
+## Security Considerations
+
+**If compute gas were made revertible** (scoped to call frames like data size and KV updates), an attacker could execute and revert expensive subcalls repeatedly within a single transaction, consuming negligible apparent compute gas while imposing real execution cost on nodes.
+
 ## Spec History
 
 This page describes the current accounting behavior.

--- a/docs/spec/evm/resource-limits.md
+++ b/docs/spec/evm/resource-limits.md
@@ -187,6 +187,11 @@ Allowing the first over-limit transaction to be included maximizes block utiliza
 Cumulative block compute gas is already indirectly constrained by the block gas limit.
 The stable protocol therefore does not need a second independent block-level compute gas ceiling.
 
+## Security Considerations
+
+**If a transaction that exceeds a runtime limit is excluded from the block rather than included as failed**, an attacker can force the sequencer to execute expensive but failing transactions at no cost — the sender never pays because the transaction is dropped.
+Including failed transactions ensures the sender always pays for consumed resources.
+
 ## Spec History
 
 - [MiniRex](../upgrades/minirex.md) introduced compute gas, data size, and KV update limits, with transaction-level data and KV limits set to 25% of the corresponding block limits.

--- a/docs/spec/evm/selfdestruct.md
+++ b/docs/spec/evm/selfdestruct.md
@@ -67,6 +67,10 @@ MegaETH initially disabled `SELFDESTRUCT` to avoid inheriting destructive accoun
 EIP-6780 is the post-Cancun Ethereum behavior and provides a widely understood baseline.
 Adopting it restores compatibility while avoiding legacy full-destruction behavior for long-lived contracts.
 
+## Security Considerations
+
+**If `SELFDESTRUCT` targeting the [beneficiary](../glossary.md#beneficiary) does not trigger gas detention**, contracts can use it to access beneficiary balance without being detained, creating an unmitigated conflict hotspot for parallel execution.
+
 ## Spec History
 
 - [MiniRex](../upgrades/minirex.md), [Rex](../upgrades/rex.md), and [Rex1](../upgrades/rex1.md) disable `SELFDESTRUCT`.


### PR DESCRIPTION
## Summary

Add `## Security Considerations` sections to all eight EVM behavioral spec pages that define gas accounting, resource limits, state mutation, or economic rules (`dual-gas-model.md`, `resource-accounting.md`, `resource-limits.md`, `gas-detention.md`, `gas-forwarding.md`, `contract-limits.md`, `precompiles.md`, `selfdestruct.md`).

Each section names concrete risks from incorrect implementation, or explicitly states "This page has no security considerations" where none apply — both per the convention in `docs/spec/AGENTS.md`.

Addresses readability finding R-001 from issue #261.

## Test plan
- Review each added section against the page's Specification section to confirm the stated risks are grounded in the normative rules.