### PR TITLE
refactor(limit): encapsulate CallFrameInfo parent-flag logic in frame_limit (#271)

### DIFF
--- a/crates/mega-evm/src/limit/compute_gas.rs
+++ b/crates/mega-evm/src/limit/compute_gas.rs
@@ -45,7 +45,7 @@ impl ComputeGasTracker {
     pub(crate) fn new(spec: MegaSpecId, tx_limit: u64) -> Self {
         Self {
             detained_limit: tx_limit,
-            frame_tracker: FrameLimitTracker::new(tx_limit),
+            frame_tracker: FrameLimitTracker::new(spec, tx_limit),
             rex1_enabled: spec.is_enabled(MegaSpecId::REX1),
             rex4_enabled: spec.is_enabled(MegaSpecId::REX4),
         }

--- a/crates/mega-evm/src/limit/data_size.rs
+++ b/crates/mega-evm/src/limit/data_size.rs
@@ -180,7 +180,7 @@ impl TxRuntimeLimit for DataSizeTracker {
     /// the frame stack aligned with the EVM's call stack.
     #[inline]
     fn push_empty_frame(&mut self) {
-        self.frame_tracker.push_intercept_frame();
+        self.frame_tracker.push_dummy_frame();
     }
 
     /// Hook called before a new execution frame is initialized.

--- a/crates/mega-evm/src/limit/data_size.rs
+++ b/crates/mega-evm/src/limit/data_size.rs
@@ -59,7 +59,6 @@ pub const STORAGE_SLOT_WRITE_SIZE: u64 = SALT_KEY_SIZE + SALT_VALUE_DELTA_STORAG
 #[derive(Debug, Clone)]
 pub(crate) struct DataSizeTracker {
     rex4_enabled: bool,
-    rex5_enabled: bool,
     frame_tracker: FrameLimitTracker<CallFrameInfo>,
 }
 
@@ -67,22 +66,7 @@ impl DataSizeTracker {
     pub(crate) fn new(spec: MegaSpecId, tx_limit: u64) -> Self {
         Self {
             rex4_enabled: spec.is_enabled(MegaSpecId::REX4),
-            rex5_enabled: spec.is_enabled(MegaSpecId::REX5),
-            frame_tracker: FrameLimitTracker::new(tx_limit),
-        }
-    }
-
-    /// Pushes a new frame onto the tracker.
-    ///
-    /// In Rex4+, delegates to `FrameLimitTracker::push_frame()` which uses
-    /// `tx_entry.remaining()` for the top-level frame (accounts for intrinsic usage)
-    /// and parent's remaining × 98/100 for nested frames.
-    /// In pre-Rex4, pushes with `u64::MAX` since per-frame limits are not enforced.
-    fn push_frame(&mut self, info: CallFrameInfo) {
-        if self.rex4_enabled {
-            self.frame_tracker.push_frame(info);
-        } else {
-            self.frame_tracker.push_frame_with_limit(u64::MAX, info);
+            frame_tracker: FrameLimitTracker::new(spec, tx_limit),
         }
     }
 
@@ -196,11 +180,7 @@ impl TxRuntimeLimit for DataSizeTracker {
     /// the frame stack aligned with the EVM's call stack.
     #[inline]
     fn push_empty_frame(&mut self) {
-        self.push_frame(CallFrameInfo {
-            target_address: None,
-            target_updated: false,
-            charged_parent_update: false,
-        });
+        self.frame_tracker.push_intercept_frame();
     }
 
     /// Hook called before a new execution frame is initialized.
@@ -219,63 +199,21 @@ impl TxRuntimeLimit for DataSizeTracker {
         match &frame_init.frame_input {
             FrameInput::Call(call_inputs) => {
                 let has_transfer = call_inputs.transfers_value();
-                // Check if parent's account info needs updating BEFORE pushing the child frame.
-                // In Rex5+, the parent's `target_updated` flag is set to true after charging
-                // so repeated value-transferring calls from the same frame don't double-charge
-                // the caller account. Pre-Rex5 keeps the old behavior (flag never set),
-                // preserving backward compatibility for stable specs.
-                // The check and mutation share a single frame_mut() borrow to avoid a redundant
-                // second call whose None branch would be unreachable.
-                let parent_needs_update = has_transfer &&
-                    match self.frame_tracker.frame_mut() {
-                        Some(entry) if !entry.info.target_updated => {
-                            if self.rex5_enabled {
-                                entry.info.target_updated = true;
-                            }
-                            true
-                        }
-                        _ => false,
-                    };
-                // Push new frame; record whether we set the parent's flag so
-                // before_frame_return_result can undo it on revert.
-                let charged_parent_update = self.rex5_enabled && parent_needs_update;
-                self.push_frame(CallFrameInfo {
-                    target_address: Some(call_inputs.target_address),
-                    target_updated: has_transfer,
-                    charged_parent_update,
-                });
+                let parent_needs_update =
+                    self.frame_tracker.push_call_frame(call_inputs.target_address, has_transfer);
                 if has_transfer {
                     if parent_needs_update {
-                        // Parent's account info update goes to child's discardable,
+                        // Parent's account info update goes to child's discardable.
                         self.record_discardable(ACCOUNT_INFO_WRITE_SIZE);
                     }
-                    // Record target account info update in child's discardable
+                    // Record target account info update in child's discardable.
                     self.record_discardable(ACCOUNT_INFO_WRITE_SIZE);
                 }
             }
             FrameInput::Create(_) => {
-                // Check if parent's account info needs updating BEFORE pushing the child frame.
-                // See the Call arm for the Rex5+ deduplication rationale.
-                let parent_needs_update = match self.frame_tracker.frame_mut() {
-                    Some(entry) if !entry.info.target_updated => {
-                        if self.rex5_enabled {
-                            entry.info.target_updated = true;
-                        }
-                        true
-                    }
-                    _ => false,
-                };
-                // Push new frame (address unknown until after init); record whether we set the
-                // parent's flag so before_frame_return_result can undo it on revert.
-                let charged_parent_update = self.rex5_enabled && parent_needs_update;
-                self.push_frame(CallFrameInfo {
-                    target_address: None,
-                    target_updated: true,
-                    charged_parent_update,
-                });
+                let parent_needs_update = self.frame_tracker.push_create_frame();
                 if parent_needs_update {
-                    // Parent's account info update goes to child's discardable,
-                    // matching the old tracker's behavior.
+                    // Parent's account info update goes to child's discardable.
                     self.record_discardable(ACCOUNT_INFO_WRITE_SIZE);
                 }
             }
@@ -291,12 +229,9 @@ impl TxRuntimeLimit for DataSizeTracker {
         if frame.data.is_create() {
             let created_address =
                 frame.data.created_address().expect("created address is none for create frame");
-            if let Some(entry) = self.frame_tracker.frame_mut() {
-                assert!(entry.info.target_address.is_none(), "created account already recorded");
-                entry.info.target_address = Some(created_address);
-                // Record account info update for created address
-                entry.discardable_usage += ACCOUNT_INFO_WRITE_SIZE;
-            }
+            self.frame_tracker.set_created_address(created_address);
+            // Record account info update for created address
+            self.record_discardable(ACCOUNT_INFO_WRITE_SIZE);
         }
     }
 
@@ -322,26 +257,14 @@ impl TxRuntimeLimit for DataSizeTracker {
     /// - **On success**: merges the frame's data into the parent frame.
     /// - **On revert/failure**: discards the frame's discardable data.
     ///
-    /// Rex5+: if the reverting child had set the parent's `target_updated` flag, the flag
+    /// Rex5+: if the reverting child had set the parent's account-update flag, the flag
     /// is reset so the next successful call from the same parent still charges the parent
-    /// account (avoiding undercounting after a revert-then-retry pattern).
+    /// account (avoiding undercounting after a revert-then-retry pattern). The unwind is
+    /// owned by `FrameLimitTracker::pop_frame_unwind_parent`.
     fn before_frame_return_result<const LAST_FRAME: bool>(&mut self, result: &FrameResult) {
         assert!(LAST_FRAME || self.frame_tracker.has_active_frame(), "frame stack is empty");
         let is_success = result.instruction_result().is_ok();
-        let child = self.frame_tracker.pop_frame(is_success);
-        if !is_success {
-            if let Some(child_entry) = child {
-                if child_entry.info.charged_parent_update {
-                    // charged_parent_update=true implies a parent frame exists
-                    // (the flag is only set when frame_mut() returned Some).
-                    self.frame_tracker
-                        .frame_mut()
-                        .expect("parent frame must exist when charged_parent_update is true")
-                        .info
-                        .target_updated = false;
-                }
-            }
-        }
+        self.frame_tracker.pop_frame_unwind_parent(is_success);
     }
 
     /// Hook called when a storage slot is written via `SSTORE`.

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -394,21 +394,10 @@ mod tests {
 
     const ADDR: Address = address!("0000000000000000000000000000000000001234");
 
-    fn tracker(rex4: bool, rex5: bool) -> FrameLimitTracker<CallFrameInfo> {
-        let spec = if rex5 {
-            MegaSpecId::REX5
-        } else if rex4 {
-            MegaSpecId::REX4
-        } else {
-            MegaSpecId::EQUIVALENCE
-        };
-        FrameLimitTracker::new(spec, u64::MAX)
-    }
-
     /// `set_created_address` on an empty frame stack must be a no-op.
     #[test]
     fn test_set_created_address_empty_stack_is_noop() {
-        let mut t = tracker(false, false);
+        let mut t = FrameLimitTracker::<CallFrameInfo>::new(MegaSpecId::EQUIVALENCE, u64::MAX);
         // No frame on the stack — should not panic, just do nothing.
         t.set_created_address(ADDR);
     }
@@ -418,7 +407,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "created account already recorded")]
     fn test_set_created_address_duplicate_panics() {
-        let mut t = tracker(false, false);
+        let mut t = FrameLimitTracker::<CallFrameInfo>::new(MegaSpecId::EQUIVALENCE, u64::MAX);
         t.push_create_frame();
         t.set_created_address(ADDR);
         t.set_created_address(ADDR); // second call must panic

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -414,7 +414,7 @@ mod tests {
     }
 
     /// `set_created_address` panics when called twice on the same CREATE frame
-    /// (invariant: target_address must be None when first filled in).
+    /// (invariant: `target_address` must be `None` when first filled in).
     #[test]
     #[should_panic(expected = "created account already recorded")]
     fn test_set_created_address_duplicate_panics() {

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -385,3 +385,42 @@ pub(crate) trait TxRuntimeLimit {
     #[inline]
     fn after_selfdestruct(&mut self, _refund: u64) {}
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::address;
+
+    use super::*;
+
+    const ADDR: Address = address!("0000000000000000000000000000000000001234");
+
+    fn tracker(rex4: bool, rex5: bool) -> FrameLimitTracker<CallFrameInfo> {
+        let spec = if rex5 {
+            MegaSpecId::REX5
+        } else if rex4 {
+            MegaSpecId::REX4
+        } else {
+            MegaSpecId::EQUIVALENCE
+        };
+        FrameLimitTracker::new(spec, u64::MAX)
+    }
+
+    /// `set_created_address` on an empty frame stack must be a no-op.
+    #[test]
+    fn test_set_created_address_empty_stack_is_noop() {
+        let mut t = tracker(false, false);
+        // No frame on the stack — should not panic, just do nothing.
+        t.set_created_address(ADDR);
+    }
+
+    /// `set_created_address` panics when called twice on the same CREATE frame
+    /// (invariant: target_address must be None when first filled in).
+    #[test]
+    #[should_panic(expected = "created account already recorded")]
+    fn test_set_created_address_duplicate_panics() {
+        let mut t = tracker(false, false);
+        t.push_create_frame();
+        t.set_created_address(ADDR);
+        t.set_created_address(ADDR); // second call must panic
+    }
+}

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -245,7 +245,7 @@ impl FrameLimitTracker<CallFrameInfo> {
     /// state-modifying account update is recorded, so the parent does not need to be marked.
     /// The frame exists only to keep the per-tracker frame stack aligned with the EVM's call
     /// stack so that the matching `pop_frame_unwind_parent` finds an entry to pop.
-    pub(crate) fn push_intercept_frame(&mut self) {
+    pub(crate) fn push_dummy_frame(&mut self) {
         self.push_call_frame_info(CallFrameInfo::default());
     }
 

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -9,22 +9,27 @@ use revm::{
 };
 use std::vec::Vec;
 
-use crate::{constants, JournalInspectTr, MegaTransaction};
+use crate::{constants, JournalInspectTr, MegaSpecId, MegaTransaction};
 
 use super::{LimitCheck, LimitKind};
 
 /// Per-frame metadata for trackers that need account update deduplication
 /// (data size and KV update trackers).
+///
+/// All fields are private to this module: the
+/// `push_call_frame` / `push_create_frame` / `pop_frame_unwind_parent` methods on
+/// `FrameLimitTracker<CallFrameInfo>` own the invariant that wires `target_updated` and
+/// `charged_parent_update` together. Callers should not touch these fields directly.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CallFrameInfo {
     /// The target address of the frame. `None` during CREATE until the address is known.
-    pub(crate) target_address: Option<Address>,
+    target_address: Option<Address>,
     /// Whether this frame's target address has been marked as updated.
-    pub(crate) target_updated: bool,
+    target_updated: bool,
     /// True when this frame caused the parent's `target_updated` to be flipped to `true`
-    /// (Rex5+ only). Used in `before_frame_return_result` to undo the parent flag on revert,
+    /// (Rex5+ only). Used by `pop_frame_unwind_parent` to undo the parent flag on revert,
     /// so a subsequent successful call from the same parent still charges the parent account.
-    pub(crate) charged_parent_update: bool,
+    charged_parent_update: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -34,6 +39,16 @@ pub(crate) struct FrameLimitTracker<I> {
     tx_entry: FrameLimitEntry<()>,
     /// Stack of child frame entries.
     frame_stack: Vec<FrameLimitEntry<I>>,
+    /// Whether Rex4 (per-frame budgeting) is active. Used by the `CallFrameInfo`
+    /// specialization to choose between `push_frame` (Rex4+) and `push_frame_with_limit`
+    /// (`u64::MAX` for pre-Rex4) when constructing call/create/intercept frames.
+    /// Other instantiations (`FrameLimitTracker<()>`) currently do not consult this flag.
+    rex4_enabled: bool,
+    /// Whether Rex5 (parent account update dedup) is active. Used by the `CallFrameInfo`
+    /// specialization to gate the `target_updated` mutation in `push_call_frame` /
+    /// `push_create_frame` and the matching unwind in `pop_frame_unwind_parent`.
+    /// Other instantiations do not consult this flag.
+    rex5_enabled: bool,
 }
 
 /// Per-frame budget entry on the frame stack.
@@ -76,8 +91,13 @@ impl<I> FrameLimitEntry<I> {
 }
 
 impl<I> FrameLimitTracker<I> {
-    pub(crate) fn new(tx_limit: u64) -> Self {
-        Self { tx_entry: FrameLimitEntry::new(tx_limit, ()), frame_stack: Vec::new() }
+    pub(crate) fn new(spec: MegaSpecId, tx_limit: u64) -> Self {
+        Self {
+            tx_entry: FrameLimitEntry::new(tx_limit, ()),
+            frame_stack: Vec::new(),
+            rex4_enabled: spec.is_enabled(MegaSpecId::REX4),
+            rex5_enabled: spec.is_enabled(MegaSpecId::REX5),
+        }
     }
 
     /// Returns the TX-level limit.
@@ -203,6 +223,126 @@ impl<I> FrameLimitTracker<I> {
             total_refund += entry.refund;
         }
         total_used.saturating_sub(total_refund)
+    }
+}
+
+impl FrameLimitTracker<CallFrameInfo> {
+    /// Pushes a new `CallFrameInfo` frame using the per-spec budget choice:
+    /// - **Rex4+**: `max_forward_limit()` (parent × 98/100, or `tx_entry.remaining()` at top
+    ///   level).
+    /// - **Pre-Rex4**: `u64::MAX` since per-frame limits are not enforced.
+    fn push_call_frame_info(&mut self, info: CallFrameInfo) {
+        if self.rex4_enabled {
+            self.push_frame(info);
+        } else {
+            self.push_frame_with_limit(u64::MAX, info);
+        }
+    }
+
+    /// Pushes a synthetic frame for inspector / access-control interception paths.
+    ///
+    /// No parent-flag mutation: an intercepted call is short-circuited before any
+    /// state-modifying account update is recorded, so the parent does not need to be marked.
+    /// The frame exists only to keep the per-tracker frame stack aligned with the EVM's call
+    /// stack so that the matching `pop_frame_unwind_parent` finds an entry to pop.
+    pub(crate) fn push_intercept_frame(&mut self) {
+        self.push_call_frame_info(CallFrameInfo::default());
+    }
+
+    /// Pushes a CALL frame and updates the parent's dedup flag.
+    ///
+    /// Returns `true` when the parent's account info should be charged by the caller
+    /// (i.e., the parent has not been marked updated yet *and* this call transfers value).
+    /// Rex5+: the parent's `target_updated` flag is set so subsequent value-transferring
+    /// calls from the same parent frame don't double-charge the caller account; the
+    /// `charged_parent_update` flag is recorded on the new child so a revert can unwind it.
+    /// Pre-Rex5: the parent flag is left untouched, preserving pre-Rex5 semantics.
+    pub(crate) fn push_call_frame(&mut self, target: Address, has_transfer: bool) -> bool {
+        let rex5_enabled = self.rex5_enabled;
+        let parent_needs_update = has_transfer &&
+            match self.frame_mut() {
+                Some(entry) if !entry.info.target_updated => {
+                    if rex5_enabled {
+                        entry.info.target_updated = true;
+                    }
+                    true
+                }
+                _ => false,
+            };
+        let charged_parent_update = rex5_enabled && parent_needs_update;
+        self.push_call_frame_info(CallFrameInfo {
+            target_address: Some(target),
+            target_updated: has_transfer,
+            charged_parent_update,
+        });
+        parent_needs_update
+    }
+
+    /// Pushes a CREATE frame and updates the parent's dedup flag.
+    ///
+    /// Returns `true` when the parent's account info should be charged by the caller
+    /// (i.e., the parent has not been marked updated yet — CREATE always increments the
+    /// caller's nonce, so there is no `has_transfer` gate).
+    /// The created address is unknown at push time; callers should fill it in via
+    /// `set_created_address` once `frame_init` completes.
+    /// Rex5+ deduplication semantics match `push_call_frame`.
+    pub(crate) fn push_create_frame(&mut self) -> bool {
+        let rex5_enabled = self.rex5_enabled;
+        let parent_needs_update = match self.frame_mut() {
+            Some(entry) if !entry.info.target_updated => {
+                if rex5_enabled {
+                    entry.info.target_updated = true;
+                }
+                true
+            }
+            _ => false,
+        };
+        let charged_parent_update = rex5_enabled && parent_needs_update;
+        self.push_call_frame_info(CallFrameInfo {
+            target_address: None,
+            target_updated: true,
+            charged_parent_update,
+        });
+        parent_needs_update
+    }
+
+    /// Records the created address on the current CREATE frame.
+    ///
+    /// Asserts that the current frame's `target_address` has not already been set,
+    /// matching the previous inline behavior. Does nothing if the frame stack is empty.
+    pub(crate) fn set_created_address(&mut self, addr: Address) {
+        if let Some(entry) = self.frame_mut() {
+            assert!(entry.info.target_address.is_none(), "created account already recorded");
+            entry.info.target_address = Some(addr);
+        }
+    }
+
+    /// Pops the current frame and, on revert, unwinds the parent's `target_updated` flag
+    /// if this child set it.
+    ///
+    /// Rex5+ only: when the reverting child had `charged_parent_update` set, the parent's
+    /// `target_updated` is reset so the next successful call from the same parent still
+    /// charges the parent account (avoiding undercounting after a revert-then-retry pattern).
+    /// Pre-Rex5 child frames have `charged_parent_update = false`, so this method behaves
+    /// identically to `pop_frame` for older specs.
+    pub(crate) fn pop_frame_unwind_parent(
+        &mut self,
+        success: bool,
+    ) -> Option<FrameLimitEntry<CallFrameInfo>> {
+        let child = self.pop_frame(success);
+        if !success {
+            if let Some(child_entry) = &child {
+                if child_entry.info.charged_parent_update {
+                    // charged_parent_update=true implies a parent frame exists
+                    // (the flag is only set when frame_mut() returned Some).
+                    self.frame_mut()
+                        .expect("parent frame must exist when charged_parent_update is true")
+                        .info
+                        .target_updated = false;
+                }
+            }
+        }
+        child
     }
 }
 

--- a/crates/mega-evm/src/limit/frame_limit.rs
+++ b/crates/mega-evm/src/limit/frame_limit.rs
@@ -325,13 +325,10 @@ impl FrameLimitTracker<CallFrameInfo> {
     /// charges the parent account (avoiding undercounting after a revert-then-retry pattern).
     /// Pre-Rex5 child frames have `charged_parent_update = false`, so this method behaves
     /// identically to `pop_frame` for older specs.
-    pub(crate) fn pop_frame_unwind_parent(
-        &mut self,
-        success: bool,
-    ) -> Option<FrameLimitEntry<CallFrameInfo>> {
+    pub(crate) fn pop_frame_unwind_parent(&mut self, success: bool) {
         let child = self.pop_frame(success);
         if !success {
-            if let Some(child_entry) = &child {
+            if let Some(child_entry) = child {
                 if child_entry.info.charged_parent_update {
                     // charged_parent_update=true implies a parent frame exists
                     // (the flag is only set when frame_mut() returned Some).
@@ -342,7 +339,6 @@ impl FrameLimitTracker<CallFrameInfo> {
                 }
             }
         }
-        child
     }
 }
 

--- a/crates/mega-evm/src/limit/kv_update.rs
+++ b/crates/mega-evm/src/limit/kv_update.rs
@@ -134,7 +134,7 @@ impl TxRuntimeLimit for KVUpdateTracker {
 
     #[inline]
     fn push_empty_frame(&mut self) {
-        self.frame_tracker.push_intercept_frame();
+        self.frame_tracker.push_dummy_frame();
     }
 
     /// Hook called before a new execution frame is initialized.

--- a/crates/mega-evm/src/limit/kv_update.rs
+++ b/crates/mega-evm/src/limit/kv_update.rs
@@ -34,7 +34,6 @@ use crate::{MegaSpecId, MegaTransaction};
 #[derive(Debug, Clone)]
 pub(crate) struct KVUpdateTracker {
     rex4_enabled: bool,
-    rex5_enabled: bool,
     frame_tracker: FrameLimitTracker<CallFrameInfo>,
 }
 
@@ -42,22 +41,7 @@ impl KVUpdateTracker {
     pub(crate) fn new(spec: MegaSpecId, tx_limit: u64) -> Self {
         Self {
             rex4_enabled: spec.is_enabled(MegaSpecId::REX4),
-            rex5_enabled: spec.is_enabled(MegaSpecId::REX5),
-            frame_tracker: FrameLimitTracker::new(tx_limit),
-        }
-    }
-
-    /// Pushes a new frame onto the tracker.
-    ///
-    /// In Rex4+, delegates to `FrameLimitTracker::push_frame()` which uses
-    /// `tx_entry.remaining()` for the top-level frame (accounts for intrinsic usage)
-    /// and parent's remaining × 98/100 for nested frames.
-    /// In pre-Rex4, pushes with `u64::MAX` since per-frame limits are not enforced.
-    fn push_frame(&mut self, info: CallFrameInfo) {
-        if self.rex4_enabled {
-            self.frame_tracker.push_frame(info);
-        } else {
-            self.frame_tracker.push_frame_with_limit(u64::MAX, info);
+            frame_tracker: FrameLimitTracker::new(spec, tx_limit),
         }
     }
 
@@ -150,11 +134,7 @@ impl TxRuntimeLimit for KVUpdateTracker {
 
     #[inline]
     fn push_empty_frame(&mut self) {
-        self.push_frame(CallFrameInfo {
-            target_address: None,
-            target_updated: false,
-            charged_parent_update: false,
-        });
+        self.frame_tracker.push_intercept_frame();
     }
 
     /// Hook called before a new execution frame is initialized.
@@ -173,63 +153,21 @@ impl TxRuntimeLimit for KVUpdateTracker {
         match &frame_init.frame_input {
             FrameInput::Call(call_inputs) => {
                 let has_transfer = call_inputs.transfers_value();
-                // Check if parent's account info needs updating BEFORE pushing the child frame.
-                // In Rex5+, the parent's `target_updated` flag is set to true after charging
-                // so repeated value-transferring calls from the same frame don't double-charge
-                // the caller account. Pre-Rex5 keeps the old behavior (flag never set),
-                // preserving backward compatibility for stable specs.
-                // The check and mutation share a single frame_mut() borrow to avoid a redundant
-                // second call whose None branch would be unreachable.
-                let parent_needs_update = has_transfer &&
-                    match self.frame_tracker.frame_mut() {
-                        Some(entry) if !entry.info.target_updated => {
-                            if self.rex5_enabled {
-                                entry.info.target_updated = true;
-                            }
-                            true
-                        }
-                        _ => false,
-                    };
-                // Push new frame; record whether we set the parent's flag so
-                // before_frame_return_result can undo it on revert.
-                let charged_parent_update = self.rex5_enabled && parent_needs_update;
-                self.push_frame(CallFrameInfo {
-                    target_address: Some(call_inputs.target_address),
-                    target_updated: has_transfer,
-                    charged_parent_update,
-                });
+                let parent_needs_update =
+                    self.frame_tracker.push_call_frame(call_inputs.target_address, has_transfer);
                 if has_transfer {
                     if parent_needs_update {
-                        // Parent's account info update goes to child's discardable,
-                        // matching the old tracker's behavior.
+                        // Parent's account info update goes to child's discardable.
                         self.record_discardable(1);
                     }
-                    // Record target account info update in child's discardable
+                    // Record target account info update in child's discardable.
                     self.record_discardable(1);
                 }
             }
             FrameInput::Create(_) => {
-                // Check if parent's account info needs updating BEFORE pushing the child frame.
-                // See the Call arm for the Rex5+ deduplication rationale.
-                let parent_needs_update = match self.frame_tracker.frame_mut() {
-                    Some(entry) if !entry.info.target_updated => {
-                        if self.rex5_enabled {
-                            entry.info.target_updated = true;
-                        }
-                        true
-                    }
-                    _ => false,
-                };
-                // Push new frame (address unknown until after init); record whether we set the
-                // parent's flag so before_frame_return_result can undo it on revert.
-                let charged_parent_update = self.rex5_enabled && parent_needs_update;
-                self.push_frame(CallFrameInfo {
-                    target_address: None,
-                    target_updated: true,
-                    charged_parent_update,
-                });
+                let parent_needs_update = self.frame_tracker.push_create_frame();
                 if parent_needs_update {
-                    // Parent's account info update goes to child's discardable,
+                    // Parent's account info update goes to child's discardable.
                     self.record_discardable(1);
                 }
             }
@@ -245,37 +183,22 @@ impl TxRuntimeLimit for KVUpdateTracker {
         if frame.data.is_create() {
             let created_address =
                 frame.data.created_address().expect("created address is none for create frame");
-            if let Some(entry) = self.frame_tracker.frame_mut() {
-                assert!(entry.info.target_address.is_none(), "created account already recorded");
-                entry.info.target_address = Some(created_address);
-                // Record account info update for created address
-                entry.discardable_usage += 1;
-            }
+            self.frame_tracker.set_created_address(created_address);
+            // Record account info update for created address
+            self.record_discardable(1);
         }
     }
 
     /// Hook called when a frame returns its result to the parent frame.
     ///
-    /// Rex5+: if the reverting child had set the parent's `target_updated` flag, the flag
+    /// Rex5+: if the reverting child had set the parent's account-update flag, the flag
     /// is reset so the next successful call from the same parent still charges the parent
-    /// account (avoiding undercounting after a revert-then-retry pattern).
+    /// account (avoiding undercounting after a revert-then-retry pattern). The unwind is
+    /// owned by `FrameLimitTracker::pop_frame_unwind_parent`.
     fn before_frame_return_result<const LAST_FRAME: bool>(&mut self, result: &FrameResult) {
         assert!(LAST_FRAME || self.frame_tracker.has_active_frame(), "frame stack is empty");
         let is_success = result.instruction_result().is_ok();
-        let child = self.frame_tracker.pop_frame(is_success);
-        if !is_success {
-            if let Some(child_entry) = child {
-                if child_entry.info.charged_parent_update {
-                    // charged_parent_update=true implies a parent frame exists
-                    // (the flag is only set when frame_mut() returned Some).
-                    self.frame_tracker
-                        .frame_mut()
-                        .expect("parent frame must exist when charged_parent_update is true")
-                        .info
-                        .target_updated = false;
-                }
-            }
-        }
+        self.frame_tracker.pop_frame_unwind_parent(is_success);
     }
 
     /// Hook called when a storage slot is written via `SSTORE`.

--- a/crates/mega-evm/src/limit/state_growth.rs
+++ b/crates/mega-evm/src/limit/state_growth.rs
@@ -103,7 +103,7 @@ pub(crate) struct StateGrowthTracker {
 
 impl StateGrowthTracker {
     pub(crate) fn new(spec: MegaSpecId, tx_limit: u64) -> Self {
-        Self { spec, frame_tracker: FrameLimitTracker::new(tx_limit) }
+        Self { spec, frame_tracker: FrameLimitTracker::new(spec, tx_limit) }
     }
 
     /// Pushes a new frame onto the tracker.


### PR DESCRIPTION
> **Generated by engineer-agent** — review carefully before merging.

## Summary

Hides `target_updated` and `charged_parent_update` behind typed methods on `FrameLimitTracker<CallFrameInfo>` (`push_call_frame`, `push_create_frame`, `pop_frame_unwind_parent`) so `DataSizeTracker` and `KVUpdateTracker` no longer duplicate the check/mutate/unwind pattern. The spec is now stored on the tracker itself, eliminating `rex5_enabled` leakage to callers. Pure refactor; Rex4/Rex5 semantics unchanged.

Fixes #271
