### PR TITLE
chore(limit): rename BlockLimiter post_execution_check to post_execution_update

### DIFF
--- a/crates/mega-evm/src/block/executor.rs
+++ b/crates/mega-evm/src/block/executor.rs
@@ -474,8 +474,10 @@ where
             outcome.tx.tx().ty() == DEPOSIT_TRANSACTION_TYPE,
         )?;
 
-        // Check block-level limits after transaction execution but before committing
-        self.block_limiter.post_execution_check(&outcome)?;
+        // Accumulate post-execution resource usage into block-level counters.
+        // This does not validate limits; over-limit enforcement happens in
+        // `pre_execution_check` before the next transaction.
+        self.block_limiter.post_execution_update(&outcome)?;
 
         let BlockMegaTransactionOutcome { tx, depositor, inner, .. } = outcome;
         let MegaTransactionOutcome { result, state, .. } = inner;

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -124,8 +124,10 @@
 //!    - During execution, tx-level limits (4-6) are enforced in EVM
 //!    - If exceeded → Transaction fails but continues to step 3
 //!
-//! 3. **Post-execution check** - [`BlockLimiter::post_execution_check`]
-//!    - If block-level violation → Discard outcome, skip, try next transaction
+//! 3. **Post-execution update** - [`BlockLimiter::post_execution_update`]
+//!    - Accumulates resource usage from the executed transaction into block-level counters
+//!    - Does not validate post-execution limits; over-limit enforcement happens before admitting
+//!      the next transaction in [`BlockLimiter::pre_execution_check`]
 //!
 //! 4. **Commit transaction** - [`crate::MegaBlockExecutor::commit_execution_outcome`]
 //!    - Include in block (with success or failed receipt)
@@ -659,8 +661,8 @@ impl BlockLimits {
 ///
 ///     let result = execute_transaction(tx);
 ///
-///     // Post-execution check and update
-///     limiter.post_execution_check(
+///     // Post-execution update
+///     limiter.post_execution_update(
 ///         tx.hash(),
 ///         result.gas_used,
 ///         tx.size(),
@@ -739,7 +741,7 @@ impl BlockLimiter {
     /// - Remaining block DA size capacity
     ///
     /// **Important**: This method does **not** modify any state. It only performs validation.
-    /// Call [`post_execution_check`](Self::post_execution_check) after execution to update
+    /// Call [`post_execution_update`](Self::post_execution_update) after execution to update
     /// usage counters.
     ///
     /// # Parameters
@@ -901,15 +903,15 @@ impl BlockLimiter {
 
     /// Update usage counters after transaction execution.
     ///
-    /// This method is called **after** transaction execution to update the limiter's cumulative
-    /// usage counters. With the new block limit strategy, this method no longer validates limits -
-    /// it only updates counters. The transaction may cause the block to exceed limits, which is
-    /// intentional to maximize block utilization.
+    /// This method is called **after** transaction execution to accumulate the executed
+    /// transaction's resource usage into the limiter's block-level counters. It does **not**
+    /// validate post-execution limits — over-limit enforcement happens in
+    /// [`pre_execution_check`](Self::pre_execution_check) before admitting the next transaction.
+    /// The transaction may cause the block to exceed limits, which is intentional to maximize
+    /// block utilization.
     ///
-    /// This method always succeeds and allows the block to exceed post-execution
-    /// limits (data, KV updates, compute gas, state growth). The exceeded state will be checked
-    /// in `pre_execution_check` before the next transaction to prevent further transactions from
-    /// being added.
+    /// The return type remains `Result` to leave room for future fallible post-execution logic;
+    /// the current implementation always returns `Ok(())`.
     ///
     /// # Parameters
     ///
@@ -938,13 +940,13 @@ impl BlockLimiter {
     /// ```rust,ignore
     /// let outcome = executor.execute_mega_transaction(tx)?;
     ///
-    /// // This always succeeds and may cause block to exceed limits
-    /// limiter.post_execution_check(&outcome)?;
+    /// // Accumulates usage; may cause block-level counters to exceed limits.
+    /// limiter.post_execution_update(&outcome)?;
     ///
     /// // Commit the transaction state
     /// executor.commit_execution_outcome(outcome)?;
     /// ```
-    pub fn post_execution_check<T: Transaction + MegaTransactionExt>(
+    pub fn post_execution_update<T: Transaction + MegaTransactionExt>(
         &mut self,
         outcome: &BlockMegaTransactionOutcome<impl RecoveredTx<T>>,
     ) -> Result<(), BlockExecutionError> {
@@ -966,7 +968,7 @@ impl BlockLimiter {
 
     /// Update usage counters after transaction execution using raw values.
     ///
-    /// This mirrors [`post_execution_check`](Self::post_execution_check) but takes precomputed
+    /// This mirrors [`post_execution_update`](Self::post_execution_update) but takes precomputed
     /// resource usage values instead of a full execution outcome.
     #[allow(clippy::too_many_arguments)]
     pub fn post_execution_update_raw(

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -652,24 +652,12 @@ impl BlockLimits {
 ///
 /// for tx in transactions {
 ///     // Pre-execution check
-///     limiter.pre_execution_check(
-///         tx.hash(),
-///         tx.gas_limit(),
-///         tx.size(),
-///         tx.da_size(),
-///     )?;
+///     limiter.pre_execution_check(tx.hash(), tx.gas_limit(), tx.size(), tx.da_size(), is_deposit)?;
 ///
-///     let result = execute_transaction(tx);
+///     let outcome = execute_transaction(tx);
 ///
 ///     // Post-execution update
-///     limiter.post_execution_update(
-///         tx.hash(),
-///         result.gas_used,
-///         tx.size(),
-///         tx.da_size(),
-///         result.data_size,
-///         result.kv_updates,
-///     )?;
+///     limiter.post_execution_update(&outcome)?;
 /// }
 /// ```
 #[derive(Debug, Clone)]

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -738,6 +738,7 @@ impl BlockLimiter {
     /// - `gas_limit`: Transaction's declared gas limit
     /// - `tx_size`: Transaction's encoded size in bytes (EIP-2718 encoding)
     /// - `da_size`: Transaction's compressed data availability size in bytes
+    /// - `is_deposit`: Whether the transaction is an L1-to-L2 deposit (exempt from DA size limits)
     ///
     /// # Returns
     ///
@@ -762,6 +763,7 @@ impl BlockLimiter {
     ///     tx.gas_limit(),
     ///     tx.encode_2718_len() as u64,
     ///     tx.estimated_da_size(),
+    ///     tx.is_deposit(),
     /// )?;
     /// ```
     pub fn pre_execution_check(


### PR DESCRIPTION
> **Generated by engineer-agent** — review carefully before merging.

## Summary

Rename `BlockLimiter::post_execution_check` to `post_execution_update` to clarify that the method only updates block-level usage counters and does not perform post-execution validation. The `Result` return type is preserved for future extensibility. This resolves issue #275.

Fixes #275
