### PR TITLE
ci(benchmark): parallelize by target on same-runner feature+baseline

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,14 +16,13 @@ permissions:
   pull-requests: write
 
 jobs:
-  benchmark:
-    name: Criterion performance check
+  # Resolve the exact commits ONCE, up front. Every bench job then checks out
+  # these fixed SHAs, so a push to the PR while the run is queued/in-flight
+  # cannot make different jobs measure different code (or mislabel the result).
+  prepare:
+    name: Resolve commits
     runs-on: ubuntu-24.04
-    # Cold compile of revm 27 + revm 38 + op-revm 8 + op-revm 20 plus running
-    # 6 bench targets twice (feature + baseline checkout) exceeded 60 min the
-    # first time. setup-rust-toolchain's cache shrinks subsequent runs, but the
-    # first run on a new branch and after dep churn still needs more room.
-    timeout-minutes: 120
+    timeout-minutes: 10
     if: >-
       github.event_name != 'issue_comment' || (
         github.event.issue.pull_request &&
@@ -32,19 +31,34 @@ jobs:
          github.event.comment.author_association == 'COLLABORATOR' ||
          github.event.comment.author_association == 'OWNER')
       )
+    outputs:
+      feature_sha: ${{ steps.resolve.outputs.feature_sha }}
+      baseline_sha: ${{ steps.resolve.outputs.baseline_sha }}
+      compare: ${{ steps.resolve.outputs.compare }}
     steps:
       - uses: actions/checkout@v4
         with:
-          submodules: recursive
           fetch-depth: 0
 
-      - name: Checkout PR branch
+      - name: Checkout PR head
         if: github.event_name == 'issue_comment'
         env:
           GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
+      - name: Resolve commits
+        id: resolve
         run: |
-          gh pr checkout ${{ github.event.issue.number }}
-          git submodule update --init --recursive
+          echo "feature_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          if [ "${{ github.event_name }}" = "issue_comment" ]; then
+            BASELINE=$(git merge-base HEAD origin/main)
+            echo "baseline_sha=$BASELINE" >> "$GITHUB_OUTPUT"
+            echo "compare=true" >> "$GITHUB_OUTPUT"
+            echo "Feature: $(git rev-parse HEAD)  Baseline: $BASELINE"
+          else
+            echo "baseline_sha=" >> "$GITHUB_OUTPUT"
+            echo "compare=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: React to comment
         if: github.event_name == 'issue_comment'
@@ -58,72 +72,91 @@ jobs:
               content: 'rocket'
             });
 
+  # One job per bench target. Each job runs the feature AND the baseline pass
+  # for its target back-to-back on the SAME runner, so the raw ns/iter compared
+  # in the regression table comes from identical hardware. Jobs run in parallel
+  # across targets, so wall-clock is ~one target's feature+baseline, not the
+  # whole suite twice.
+  bench:
+    name: Bench ${{ matrix.target }}
+    needs: prepare
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [revm_bench, mega_bench, block_bench, transact, comp_cost, ctt]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      # Same-repo PR heads are already in `origin` after the full-depth fetch,
+      # but fork PRs are not — `gh pr checkout` adds the fork remote and fetches
+      # the head so the pinned `feature_sha` below is resolvable.
+      - name: Fetch PR head
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh pr checkout ${{ github.event.issue.number }}
+
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
-      # Run feature benchmarks (current branch)
-      - name: Run feature benchmarks
-        env:
-          BENCH_TARGETS: revm_bench mega_bench block_bench transact comp_cost ctt
+      - name: Run feature benchmark
         run: |
-          : > feature_output.txt
-          for bench in $BENCH_TARGETS; do
-            cargo bench -p mega-evm --bench "$bench" -- --output-format bencher | tee -a feature_output.txt
-          done
-
-      # On /benchmark comment: also run baseline benchmarks for comparison
-      - name: Determine baseline commit
-        if: github.event_name == 'issue_comment'
-        id: baseline
-        run: |
-          echo "feature_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-          BASELINE=$(git merge-base HEAD origin/main)
-          echo "commit=$BASELINE" >> "$GITHUB_OUTPUT"
-          echo "Baseline commit: $BASELINE"
-
-      - name: Run baseline benchmarks
-        if: github.event_name == 'issue_comment'
-        env:
-          BENCH_TARGETS: revm_bench mega_bench block_bench transact comp_cost ctt
-        run: |
-          git checkout ${{ steps.baseline.outputs.commit }}
-          trap 'git checkout -' EXIT
+          git checkout --quiet ${{ needs.prepare.outputs.feature_sha }}
           git submodule update --init --recursive
-          AVAILABLE_BENCHES=$(python3 - <<'PY'
-          bench_names = []
-          in_bench = False
+          cargo bench -p mega-evm --bench ${{ matrix.target }} -- --output-format bencher \
+            | tee "feature_${{ matrix.target }}.txt"
 
-          with open("crates/mega-evm/Cargo.toml", encoding="utf-8") as f:
-              for line in f:
-                  stripped = line.strip()
-                  if stripped == "[[bench]]":
-                      in_bench = True
-                      continue
-                  if stripped.startswith("[") and stripped != "[[bench]]":
-                      in_bench = False
-                  if in_bench and stripped.startswith("name = "):
-                      name = stripped.split("=", 1)[1].strip().strip('"')
-                      bench_names.append(name)
-                      in_bench = False
+      - name: Run baseline benchmark
+        if: needs.prepare.outputs.compare == 'true'
+        run: |
+          git checkout --quiet ${{ needs.prepare.outputs.baseline_sha }}
+          git submodule update --init --recursive
+          if grep -q 'name = "${{ matrix.target }}"' crates/mega-evm/Cargo.toml; then
+            cargo bench -p mega-evm --bench ${{ matrix.target }} -- --output-format bencher \
+              | tee "baseline_${{ matrix.target }}.txt"
+          else
+            echo "Skipping baseline benchmark '${{ matrix.target }}' (not present at baseline commit)"
+          fi
 
-          for name in bench_names:
-              print(name)
-          PY
-          )
-          : > baseline_output.txt
-          for bench in $BENCH_TARGETS; do
-            if printf '%s\n' "$AVAILABLE_BENCHES" | grep -qx "$bench"; then
-              cargo bench -p mega-evm --bench "$bench" -- --output-format bencher | tee -a baseline_output.txt
-            else
-              echo "Skipping baseline benchmark '$bench' (not present at baseline commit)"
-            fi
-          done
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-output-${{ matrix.target }}
+          path: |
+            feature_${{ matrix.target }}.txt
+            baseline_${{ matrix.target }}.txt
+          if-no-files-found: ignore
+
+  # Join all per-target outputs and post the comparison comment. Cheap (no
+  # compile, no benches) so it gets a short budget.
+  compare:
+    name: Compare and comment on PR
+    needs: [prepare, bench]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: needs.prepare.outputs.compare == 'true'
+    steps:
+      - name: Download all bench results
+        uses: actions/download-artifact@v4
+        with:
+          pattern: bench-output-*
+          merge-multiple: true
+
+      - name: Aggregate per-target outputs
+        run: |
+          cat feature_*.txt > feature_output.txt 2>/dev/null || : > feature_output.txt
+          cat baseline_*.txt > baseline_output.txt 2>/dev/null || : > baseline_output.txt
 
       - name: Compare and comment on PR
-        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
@@ -226,13 +259,15 @@ jobs:
             }
 
             let body = '## Criterion Benchmark Comparison\n\n';
-            const featureSha = '${{ steps.baseline.outputs.feature_sha }}';
-            body += `> Comparing [\`baseline\`](${context.payload.repository.html_url}/commit/${{ steps.baseline.outputs.commit }})`;
+            const featureSha = '${{ needs.prepare.outputs.feature_sha }}';
+            const baselineSha = '${{ needs.prepare.outputs.baseline_sha }}';
+            body += `> Comparing [\`baseline\`](${context.payload.repository.html_url}/commit/${baselineSha})`;
             body += ` → [\`feature\`](${context.payload.repository.html_url}/commit/${featureSha})\n\n`;
+            body += '> Each target\'s feature and baseline rows are measured back-to-back on the same runner; raw ns are comparable within a target, not across targets.\n\n';
 
             if (baselineGap) {
               body += '### Baseline gap (HEAD only — how far is each EVM layer from `revm_pinned`)\n';
-              body += '\n_`rex4` is the current production spec — that\'s the row to read for "user-visible mega gap". The other rows are diagnostic: they show which layer adds cost._\n';
+              body += '\n_`rex4` is the current production spec — that\'s the row to read for "user-visible mega gap". `rex5` is the latest spec under active development. The other rows are diagnostic: they show which layer adds cost._\n';
               body += baselineGap;
               body += '\n---\n\n';
               body += '### PR-base → PR-head regression check\n\n';
@@ -300,7 +335,7 @@ jobs:
               body: body
             });
 
-      - name: Upload results
+      - name: Upload combined results
         if: always()
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -11,9 +11,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege by default: only the jobs that post to the PR get write, and
+# the job that compiles + runs untrusted PR code (`bench`) gets read-only — so a
+# malicious PR run with `/benchmark` has no write-scoped token to abuse.
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   # Resolve the exact commits ONCE, up front. Every bench job then checks out
@@ -23,6 +25,10 @@ jobs:
     name: Resolve commits
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # Reacts to the triggering comment; does not execute PR code.
+    permissions:
+      contents: read
+      pull-requests: write
     if: >-
       github.event_name != 'issue_comment' || (
         github.event.issue.pull_request &&
@@ -82,6 +88,12 @@ jobs:
     needs: prepare
     runs-on: ubuntu-24.04
     timeout-minutes: 90
+    # This job compiles and runs untrusted PR code — keep it read-only so there
+    # is no write-scoped token to exfiltrate. `pull-requests: read` lets
+    # `gh pr checkout` resolve the (fork) PR head.
+    permissions:
+      contents: read
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -144,6 +156,10 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     if: needs.prepare.outputs.compare == 'true'
+    # Posts the comparison comment; consumes only artifacts, never PR code.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Download all bench results
         uses: actions/download-artifact@v4

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,43 +42,44 @@ jobs:
       baseline_sha: ${{ steps.resolve.outputs.baseline_sha }}
       compare: ${{ steps.resolve.outputs.compare }}
     steps:
-      # Checks out the BASE repo's default branch only (trusted code). The PR
-      # head is never checked out here — we fetch its commit object and read the
-      # SHA off the commit graph, so this write-privileged job never materializes
-      # untrusted PR code in its working tree.
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Resolve commits
+      # Resolve the feature/baseline commits via the API ONLY — no checkout and
+      # no fetch of the PR ref. This write-privileged job therefore never brings
+      # untrusted PR code (or even a PR-controlled ref) into the workspace; the
+      # actual PR code is only ever materialized in the read-only `bench` job.
+      - name: Resolve commits and react
         id: resolve
-        run: |
-          if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            # GitHub maintains refs/pull/<n>/head in the base repo even for fork
-            # PRs; fetch just that commit object (no checkout, no working tree).
-            git fetch --no-tags origin "pull/${{ github.event.issue.number }}/head"
-            FEATURE=$(git rev-parse FETCH_HEAD)
-            BASELINE=$(git merge-base "$FEATURE" origin/main)
-            echo "feature_sha=$FEATURE" >> "$GITHUB_OUTPUT"
-            echo "baseline_sha=$BASELINE" >> "$GITHUB_OUTPUT"
-            echo "compare=true" >> "$GITHUB_OUTPUT"
-            echo "Feature: $FEATURE  Baseline: $BASELINE"
-          else
-            echo "feature_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-            echo "baseline_sha=" >> "$GITHUB_OUTPUT"
-            echo "compare=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: React to comment
-        if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
         with:
           script: |
-            github.rest.reactions.createForIssueComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+            if (context.eventName !== 'issue_comment') {
+              // schedule / workflow_dispatch: benchmark the checked-out ref,
+              // no baseline comparison.
+              core.setOutput('feature_sha', context.sha);
+              core.setOutput('baseline_sha', '');
+              core.setOutput('compare', 'false');
+              return;
+            }
+            const { owner, repo } = context.repo;
+            const pull_number = context.payload.issue.number;
+            const pr = await github.rest.pulls.get({ owner, repo, pull_number });
+            const featureSha = pr.data.head.sha;
+            // GitHub's compare endpoint returns the merge-base of the PR base
+            // branch and the PR head — same commit `git merge-base` would pick.
+            const cmp = await github.rest.repos.compareCommitsWithBasehead({
+              owner,
+              repo,
+              basehead: `${pr.data.base.ref}...${featureSha}`,
+            });
+            const baselineSha = cmp.data.merge_base_commit.sha;
+            core.setOutput('feature_sha', featureSha);
+            core.setOutput('baseline_sha', baselineSha);
+            core.setOutput('compare', 'true');
+            core.info(`Feature: ${featureSha}  Baseline: ${baselineSha}`);
+            await github.rest.reactions.createForIssueComment({
+              owner,
+              repo,
               comment_id: context.payload.comment.id,
-              content: 'rocket'
+              content: 'rocket',
             });
 
   # One job per bench target. Each job runs the feature AND the baseline pass

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,26 +42,29 @@ jobs:
       baseline_sha: ${{ steps.resolve.outputs.baseline_sha }}
       compare: ${{ steps.resolve.outputs.compare }}
     steps:
+      # Checks out the BASE repo's default branch only (trusted code). The PR
+      # head is never checked out here — we fetch its commit object and read the
+      # SHA off the commit graph, so this write-privileged job never materializes
+      # untrusted PR code in its working tree.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Checkout PR head
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh pr checkout ${{ github.event.issue.number }}
-
       - name: Resolve commits
         id: resolve
         run: |
-          echo "feature_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
           if [ "${{ github.event_name }}" = "issue_comment" ]; then
-            BASELINE=$(git merge-base HEAD origin/main)
+            # GitHub maintains refs/pull/<n>/head in the base repo even for fork
+            # PRs; fetch just that commit object (no checkout, no working tree).
+            git fetch --no-tags origin "pull/${{ github.event.issue.number }}/head"
+            FEATURE=$(git rev-parse FETCH_HEAD)
+            BASELINE=$(git merge-base "$FEATURE" origin/main)
+            echo "feature_sha=$FEATURE" >> "$GITHUB_OUTPUT"
             echo "baseline_sha=$BASELINE" >> "$GITHUB_OUTPUT"
             echo "compare=true" >> "$GITHUB_OUTPUT"
-            echo "Feature: $(git rev-parse HEAD)  Baseline: $BASELINE"
+            echo "Feature: $FEATURE  Baseline: $BASELINE"
           else
+            echo "feature_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
             echo "baseline_sha=" >> "$GITHUB_OUTPUT"
             echo "compare=false" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
## Summary

Reworks the Criterion benchmark workflow so it no longer hits the 120-minute timeout, while keeping the comparison statistically sound.

The previous single job ran the whole bench suite **twice back-to-back** (feature pass, then baseline pass) on one runner. As the suite grew (vanilla revm/op-revm baselines, `attack_replay`, more spec rows) the two passes exceeded the 120-minute cap and the job was cancelled mid-baseline.

### New structure

- **`prepare`** — resolves the feature SHA (PR head) and baseline SHA (merge-base with `main`) **once**. Every bench job checks out these fixed SHAs, so a push to the PR while the run is queued/in-flight cannot make jobs measure different code or mislabel the result.
- **`bench`** — one job **per bench target** (matrix). Each job runs that target's feature and baseline passes **back-to-back on the same runner**, so the raw `ns/iter` compared in the regression table comes from identical hardware. Jobs run in parallel across targets, so wall-clock is ~one target's two passes instead of the whole suite twice.
- **`compare`** — joins the per-target outputs and posts the PR comment (unchanged comparison logic).

This keeps the parallelism win while **restoring the same-commit and same-runner properties** the original single-job design had.

### Notes

- `issue_comment`-triggered workflows always use the workflow file from the **default branch**, so this parallel structure only takes effect once merged to `main`; it cannot be exercised on this PR itself.
- `compare` requires all matrix `bench` jobs to succeed (same as the old single job failing wholesale on any bench error). `fail-fast: false` lets the other targets finish for artifact upload.
- Heavy targets (e.g. `comp_cost`) run as their own job; if one ever approaches the 90-minute per-job budget it can be chunked further by sub-bench.