### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2942,7 +2942,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evme"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2980,7 +2980,7 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -2991,7 +2991,7 @@ dependencies = [
 
 [[package]]
 name = "mega-t8n"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5112,7 +5112,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-test"
-version = "1.5.1"
+version = "1.6.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = []
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
 [workspace.package]
-version = "1.5.1"
+version = "1.6.0"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -121,9 +121,9 @@ too_long_first_doc_paragraph = "allow"
 
 [workspace.dependencies]
 # megaeth
-mega-evm = { path = "./crates/mega-evm", version = "1.5.1", default-features = false }
-mega-system-contracts = { path = "./crates/system-contracts", version = "1.5.1", default-features = false }
-state-test = { path = "./crates/state-test", version = "1.5.1" }
+mega-evm = { path = "./crates/mega-evm", version = "1.6.0", default-features = false }
+mega-system-contracts = { path = "./crates/system-contracts", version = "1.6.0", default-features = false }
+state-test = { path = "./crates/state-test", version = "1.6.0" }
 
 # revm
 op-revm = { version = "8.1.0", default-features = false }


### PR DESCRIPTION
## Summary
- Bump workspace version from 1.5.1 to 1.6.0
- Update internal workspace dependency version pins (mega-evm, mega-system-contracts, state-test) to 1.6.0 to keep them consistent for crates.io publishing