### PR TITLE
docs: clarify KeylessDeploy error wire is non-consensus

### DIFF
--- a/crates/mega-evm/src/sandbox/error.rs
+++ b/crates/mega-evm/src/sandbox/error.rs
@@ -108,13 +108,15 @@ pub enum KeylessDeployError {
     /// itself before constructing the sandbox transaction.
     SignerHasCode,
     /// Internal sandbox failure (DB I/O, header validation, etc.).
-    /// Selector-only — precompile return data is consensus-affecting, so the wire must
-    /// not pin consensus to upstream revm/op-revm `Display` impls.
+    /// Selector-only so the top-level error ABI stays stable and does not depend on
+    /// upstream revm/op-revm `Display` text. The interceptor only runs at call depth 0,
+    /// so this returndata has no inner caller to read it and never reaches a consensus
+    /// root; the selector-only shape is for off-chain decoder/tooling stability.
     InternalError,
     /// Sandbox rejected the inner transaction as a tx-validation error
     /// (`IsTxError::is_tx_error() == true`). A dedicated selector lets relayer-side
     /// decoders distinguish this from a genuine internal failure. Selector-only for the
-    /// same consensus-decoupling reason as `InternalError`.
+    /// same ABI-stability reason as `InternalError`.
     InvalidTransaction,
     /// The keylessDeploy call was not intercepted (only returned by Solidity contract for inner
     /// calls)
@@ -290,9 +292,9 @@ mod tests {
     use super::*;
 
     /// `InternalError` and `InvalidTransaction` carry no payload on the wire, so a
-    /// roundtrip MUST produce the same variant. Pinned because both selectors are
-    /// reachable on-chain via `RETURNDATACOPY` and any divergence between
-    /// `encode_error_result` and `decode_error_result` would break consensus.
+    /// roundtrip MUST produce the same variant. Pinned because these selectors are the
+    /// off-chain error ABI (RPC, traces, relayer decoders); a divergence between
+    /// `encode_error_result` and `decode_error_result` would silently break those decoders.
     #[test]
     fn test_internal_error_roundtrip_is_selector_only() {
         let encoded = encode_error_result(KeylessDeployError::InternalError);
@@ -311,7 +313,7 @@ mod tests {
         ));
     }
 
-    /// `InitCodeTooLarge { size, max }` is a consensus-visible ABI selector. Pinning the
+    /// `InitCodeTooLarge { size, max }` is an externally visible ABI selector. Pinning the
     /// round-trip catches any drift between the Solidity error definition and the Rust
     /// encode/decode (e.g. forgotten arm in `encode_error_result` or `decode_error_result`,
     /// or accidental field reordering).

--- a/docs/spec/system-contracts/keyless-deploy.md
+++ b/docs/spec/system-contracts/keyless-deploy.md
@@ -229,8 +229,9 @@ The outer KeylessDeploy call MUST revert with `InvalidTransaction()`, and the si
 It MUST be returned when the recovered signer's parent-state bytecode is non-empty and is not a valid EIP-7702 delegation designation, unless EIP-3607 enforcement is disabled by node configuration.
 This enforces the EIP-3607 caller-with-code rule, keeping the keyless-deploy validation surface aligned with the canonical transaction validation path.
 
-`InvalidTransaction()`, `InternalError()`, and `SignerHasCode()` are selector-only because return data is reachable on-chain through `RETURNDATACOPY` into storage and the state root.
-Encoding free-form error text into the wire payload would pin consensus to non-stable error wording.
+`InvalidTransaction()`, `InternalError()`, and `SignerHasCode()` are selector-only so the top-level KeylessDeploy error ABI stays stable and does not depend on upstream internal error text.
+The KeylessDeploy interceptor is active only at call depth 0; calls from contracts are not intercepted and MUST revert through the on-chain `NotIntercepted()` path, so sandbox validation/internal-error returndata is not observable by an inner caller's `RETURNDATASIZE` or `RETURNDATACOPY` instructions.
+This top-level returndata can affect RPC responses, traces, relayer decoders, and exact-output replay tooling, but it is not included in transaction receipts and cannot be copied into contract storage through KeylessDeploy's intercepted path.
 
 ## Constants
 

--- a/docs/spec/upgrades/rex5.md
+++ b/docs/spec/upgrades/rex5.md
@@ -272,7 +272,12 @@ A transaction that cannot fit its final Mega-side intrinsic or floor gas require
   It is raised when the recovered signer's parent-state bytecode is non-empty and is not a valid EIP-7702 delegation designation, unless the EIP-3607 check is disabled.
   This re-enforces EIP-3607 because the deposit-style sandbox transaction bypasses the standard account nonce-and-code validation.
 
-`InvalidTransaction()`, `InternalError()`, and `SignerHasCode()` are selector-only because precompile return data is reachable on-chain via `RETURNDATACOPY` → `SSTORE` → state root, so coupling the wire format to a non-stable internal error string would pin consensus to it.
+`InvalidTransaction()`, `InternalError()`, and `SignerHasCode()` are selector-only so the top-level KeylessDeploy error ABI stays stable and does not depend on upstream internal error text.
+KeylessDeploy interception is active only at call depth 0; calls from contracts are not intercepted and therefore cannot observe sandbox validation/internal-error payloads with `RETURNDATASIZE` or `RETURNDATACOPY`.
+This ABI refactor can affect RPC responses, traces, relayer decoders, and exact-output replay tooling, but it does not create a state-root or receipt-root replay dependency through an inner-call returndata path.
+In consensus terms the change in this error's returndata from `InternalError(string)` to `InternalError()` is a non-breaking, off-chain interface change — comparable to changing an RPC error/response format — so it carries no hard-fork or coordinated-activation requirement.
+Because this returndata is never consensus-observable, the encoding is not spec-gated: the node emits the selector-only form uniformly across all specs.
+The `InternalError(string)` form above therefore describes the original Rex2 implementation, not the current node's output when re-executing a pre-Rex5 block.
 See [keyless-deploy.md](../system-contracts/keyless-deploy.md) for the normative error list.
 
 ### 16. Precompile Compute-Gas Cap


### PR DESCRIPTION
## Summary

Documentation and code-comment clarification only — no behavior change.

This corrects the stated rationale for why the KeylessDeploy sandbox errors (`InvalidTransaction()`, `InternalError()`, `SignerHasCode()`) use a selector-only wire format, and records why no spec gate is needed for the `InternalError(string)` → `InternalError()` shape.

The previous docs and comments justified selector-only on the grounds that the returndata is consensus-reachable via `RETURNDATACOPY` → `SSTORE` → state root. That rationale is incorrect: the KeylessDeploy interceptor runs only at call depth 0, so its returndata has no inner caller that could observe it via `RETURNDATASIZE` / `RETURNDATACOPY`, and it is therefore absent from every consensus-committed carrier (state root, receipts root, gas used, logs, data-size metering). The selector-only shape exists for off-chain ABI/decoder stability, not consensus decoupling.

## Why no spec gate

Because the wire is structurally non-consensus, the selector-only encoding is replay-safe and emitted uniformly across all specs — no gating required. The `InternalError(string)` → `InternalError()` change is a non-breaking, off-chain interface change (comparable to changing an RPC error/response format), carrying no hard-fork or coordinated-activation requirement.

The single load-bearing fact is the `depth == 0` interception invariant: a contract calling KeylessDeploy at depth > 0 is not intercepted and falls through to the on-chain `NotIntercepted()` revert path. This invariant is regression-guarded by `test_keyless_deploy_not_intercepted_for_inner_calls`.

## Changes

- `crates/mega-evm/src/sandbox/error.rs` — correct the `InternalError` / `InvalidTransaction` variant comments and the roundtrip-test comments to describe the off-chain-ABI rationale instead of the incorrect consensus one.
- `docs/spec/system-contracts/keyless-deploy.md` — restate the selector-only rationale around the depth-0 invariant.
- `docs/spec/upgrades/rex5.md` — same restatement, plus an explicit note that the encoding is not spec-gated and that the `InternalError(string)` form describes the original Rex2 implementation rather than the current node's re-execution output.
