### PR TITLE
perf(evm): trim per-opcode hot path and pre-execution scans

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,22 @@ The following paths are common sources of leakage:
 
 When adding a new per-frame gas mechanism, verify that all three paths handle it correctly and add tests for each.
 
+### Resource-Limit Check Protocol
+
+The per-opcode hot path records and checks only the compute-gas dimension (`AdditionalLimit::record_compute_gas`).
+Correctness of the other three dimensions (data size, KV updates, state growth) rests on a protocol instead of a per-opcode fan-out across all four trackers:
+
+1. **Every non-compute mutation site must latch.**
+   Any code that records data-size/KV/state-growth usage during execution (`on_sstore`, `on_log`, `record_oracle_hint_bytes`, the frame-lifecycle hooks) must run `check_limit()` itself, latching any exceed into `has_exceeded_limit`.
+   The latch is surfaced by the leading short-circuit of the next `record_compute_gas` call, so the halt lands on the same opcode as the pre-protocol fan-out did.
+2. **Pre-inner recorders must NOT latch.**
+   A site that records usage _before_ its inner instruction executes (currently only SELFDESTRUCT beneficiary creation) must record without latching: the inner instruction can still fail, the frame then discards the usage, and an early latch would stick and rewrite the frame's real result.
+   Such opcodes use a trailing all-dimension check (`record_compute_gas_all_dims`) that runs only after the inner instruction succeeds.
+3. **Compute gas is always recorded.**
+   `record_compute_gas` must record before surfacing any latched exceed — the recorded total feeds the transaction outcome and block-level compute accounting even for transactions halted on another dimension.
+
+When adding an opcode or mutation site that touches a non-compute dimension, decide whether it records after or before its inner instruction, follow the matching case above, and add a test asserting the exceed halts at that opcode.
+
 ## Test Organization (`crates/mega-evm/tests/`)
 
 Tests are organized by spec: `equivalence/`, `mini_rex/` (12 modules), `rex/`, `rex2/`, `rex3/`, `rex4/`, `rex5/`, and `block_executor/`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,9 @@ Correctness of the other three dimensions (data size, KV updates, state growth) 
 3. **Compute gas is always recorded.**
    `record_compute_gas` must record before surfacing any latched exceed — the recorded total feeds the transaction outcome and block-level compute accounting even for transactions halted on another dimension.
 
+Rule 1 is backed by a `debug_assert!` in `record_compute_gas`: if a non-compute dimension is over its limit but not yet latched, the assert trips at the exact opcode whose mutation site forgot to call `check_limit()`.
+The sub-tracker checks are non-mutating, so the guard compiles out of release builds.
+
 When adding an opcode or mutation site that touches a non-compute dimension, decide whether it records after or before its inner instruction, follow the matching case above, and add a test asserting the exceed halts at that opcode.
 
 ## Test Organization (`crates/mega-evm/tests/`)

--- a/crates/mega-evm/benches/mega_bench.rs
+++ b/crates/mega-evm/benches/mega_bench.rs
@@ -13,15 +13,26 @@
 //! - **`selfdestruct`**: SELFDESTRUCT behavior across specs
 //! - **`call_value_empty_account`**: CALL with value to empty accounts (dynamic gas)
 //! - **`mixed_workload`**: Realistic combined workload
+//! - **`eip7702_authlist`**: REX5 pre-execution authority-list scan scaling with list size
+//! - **`staticcall_selfdestruct`**: SELFDESTRUCT inside a STATICCALL frame vs a STOP control
 
 #![allow(missing_docs)]
 
+use alloy_eips::eip7702::{Authorization, RecoveredAuthority, RecoveredAuthorization};
 use alloy_primitives::{address, Address, Bytes, U256};
-use criterion::{criterion_group, criterion_main, Criterion};
-use mega_evm::{test_utils::BytecodeBuilder, MegaSpecId};
-use revm::bytecode::opcode::{
-    ADD, CALL, COINBASE, CREATE, CREATE2, DELEGATECALL, GAS, LOG0, LOG1, LOG2, LOG4, NUMBER, POP,
-    PUSH0, SELFDESTRUCT, SLOAD, SSTORE, STATICCALL, STOP, TIMESTAMP,
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use mega_evm::{
+    revm::inspector::NoOpInspector,
+    test_utils::{BytecodeBuilder, MemoryDatabase},
+    EmptyExternalEnv, MegaContext, MegaEvm, MegaSpecId, MegaTransaction,
+};
+use revm::{
+    bytecode::opcode::{
+        ADD, CALL, COINBASE, CREATE, CREATE2, DELEGATECALL, GAS, LOG0, LOG1, LOG2, LOG4, NUMBER,
+        POP, PUSH0, SELFDESTRUCT, SLOAD, SSTORE, STATICCALL, STOP, TIMESTAMP,
+    },
+    context::tx::TxEnvBuilder,
+    ExecuteEvm as _,
 };
 
 mod common;
@@ -668,6 +679,155 @@ fn bench_mixed_workload(c: &mut Criterion) {
     group.finish();
 }
 
+//
+// ============================================================================
+// EIP-7702 Authorization-List Scaling Benchmark
+// ============================================================================
+//
+// REX5 records state growth for EIP-7702 authority accounts during
+// pre-execution (`record_eip7702_authority_state_growth`). For each
+// authorization it consults a transaction-local collection of already-seen
+// authorities; with a `Vec` that lookup is O(N) per authorization, hence O(N²)
+// over the list — a node-CPU amplification an attacker can drive with ~1200
+// unique authorities in one 30M-gas type-4 tx. The `BTreeMap`-based
+// implementation bounds the pass at O(N log N).
+//
+// The benchmark sweeps the authority count so a quadratic term shows up as
+// super-linear growth (a map-based implementation grows linearly). Authorities
+// are pre-recovered (`RecoveredAuthority::Valid`) so no ecrecover cost dilutes
+// the measured scan; each is distinct and absent from state, so every one
+// passes validation and exercises the full lookup.
+//
+// This bench builds the mega EVM directly instead of going through the
+// `Workload` harness: `TxSpec` is deliberately backend-agnostic and carries no
+// authorization list, and only mega rows are meaningful for this REX5-only
+// pre-execution path.
+//
+
+const AUTH_DELEGATE: Address = address!("0000000000000000000000000000000000900001");
+
+fn make_recovered_auth_list(n: usize) -> Vec<RecoveredAuthorization> {
+    (0..n)
+        .map(|i| {
+            let mut bytes = [0u8; 20];
+            bytes[12..20].copy_from_slice(&((i as u64) + 0x0010_0000).to_be_bytes());
+            RecoveredAuthorization::new_unchecked(
+                // chain_id 0 = chain-agnostic, always valid regardless of cfg
+                Authorization { chain_id: U256::ZERO, address: AUTH_DELEGATE, nonce: 0 },
+                RecoveredAuthority::Valid(Address::from(bytes)),
+            )
+        })
+        .collect()
+}
+
+fn bench_eip7702_authlist(c: &mut Criterion) {
+    let mut group = c.benchmark_group("eip7702_authlist");
+    for &n in &[150usize, 400, 800, 1200] {
+        let auth_list = make_recovered_auth_list(n);
+        let db =
+            MemoryDatabase::default().account_balance(CALLER, U256::from(10).pow(U256::from(24)));
+        group.bench_function(format!("rex5/{n}"), |b| {
+            b.iter(|| {
+                let mut context = MegaContext::new(db.clone(), MegaSpecId::REX5);
+                // Match the harness's Mega subject: the op-revm base panics on
+                // unset operator-fee fields, so zero them explicitly.
+                context.modify_chain(|chain| {
+                    chain.operator_fee_scalar = Some(U256::ZERO);
+                    chain.operator_fee_constant = Some(U256::ZERO);
+                });
+                let mut evm = MegaEvm::<_, NoOpInspector, EmptyExternalEnv>::new(context);
+                let tx = TxEnvBuilder::new()
+                    .caller(CALLER)
+                    .call(CONTRACT)
+                    .gas_limit(100_000_000)
+                    .authorization_list_recovered(auth_list.clone())
+                    .build_fill();
+                let mut mega_tx = MegaTransaction::new(tx);
+                mega_tx.enveloped_tx = Some(Bytes::new());
+                black_box(evm.transact(mega_tx))
+            })
+        });
+    }
+    group.finish();
+}
+
+//
+// ============================================================================
+// STATICCALL → SELFDESTRUCT Unmetered-Work Benchmark
+// ============================================================================
+//
+// Without the `is_static` early-exit guard, the REX5 SELFDESTRUCT wrapper
+// (`storage_gas_ext::selfdestruct`) inspects the beneficiary and caller
+// accounts and runs SALT account-creation pricing BEFORE the inner interpreter
+// reaches revm's static-context check and halts. Inside a STATICCALL frame
+// that host work is always wasted: the frame reverts. An attacker repeats it
+// via STATICCALL → selfdestruct in a loop.
+//
+// The parent loops fixed-gas STATICCALLs to a SELFDESTRUCT child; a STOP-child
+// row is the control the early-exit guard must NOT change, so the wasted host
+// work is the difference between the two rows.
+//
+
+const SD_CHILD: Address = address!("00000000000000000000000000000000000a0001");
+
+/// Parent that performs `iterations` STATICCALLs to `target`, each forwarding a
+/// fixed `gas_each` (not all remaining gas, so one reverting child cannot drain
+/// the parent), then STOPs.
+fn make_repeated_staticcall_fixedgas(target: Address, gas_each: u64, iterations: usize) -> Bytes {
+    let mut builder = BytecodeBuilder::default();
+    for _ in 0..iterations {
+        builder = builder
+            .push_number(0u64) // retSize
+            .push_number(0u64) // retOffset
+            .push_number(0u64) // argsSize
+            .push_number(0u64) // argsOffset
+            .push_address(target)
+            .push_number(gas_each) // forwarded gas (fixed)
+            .append(STATICCALL)
+            .append(POP);
+    }
+    builder.append(STOP).build()
+}
+
+fn bench_staticcall_selfdestruct(c: &mut Criterion) {
+    const ITERS: usize = 500;
+    const GAS_EACH: u64 = 200_000;
+    let parent_code = make_repeated_staticcall_fixedgas(SD_CHILD, GAS_EACH, ITERS);
+    // SELFDESTRUCT(beneficiary=0): halts on the static-context check inside revm.
+    let sd_child: Bytes = vec![PUSH0, SELFDESTRUCT].into();
+    // control: pure STOP — same STATICCALL frame cost, no SELFDESTRUCT host work.
+    let stop_child: Bytes = vec![STOP].into();
+
+    let workload = |child_code: Bytes| {
+        Workload::single(
+            vec![
+                Account::new(CONTRACT).code(parent_code.clone()),
+                // fund the child so the SELFDESTRUCT `has_value` branch (SALT
+                // pricing) triggers
+                Account::new(SD_CHILD).code(child_code).balance(U256::from(1u64)),
+                Account::new(CALLER).balance(U256::from(10).pow(U256::from(18))),
+            ],
+            TxSpec::call(CALLER, CONTRACT).gas_limit(FEATURE_GAS_LIMIT),
+        )
+    };
+
+    const REX5_ONLY: &[(&str, MegaSpecId)] = &[("rex5", MegaSpecId::REX5)];
+    let mut group = c.benchmark_group("staticcall_selfdestruct");
+    register_mega_specs_suffixed(
+        &mut group,
+        REX5_ONLY,
+        &format!("selfdestruct_child/{ITERS}"),
+        &workload(sd_child),
+    );
+    register_mega_specs_suffixed(
+        &mut group,
+        REX5_ONLY,
+        &format!("stop_child/{ITERS}"),
+        &workload(stop_child),
+    );
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_volatile_data,
@@ -681,5 +841,7 @@ criterion_group!(
     bench_delegatecall_system_contract,
     bench_oracle_sload,
     bench_mixed_workload,
+    bench_eip7702_authlist,
+    bench_staticcall_selfdestruct,
 );
 criterion_main!(benches);

--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "std"))]
 use alloc as std;
-use std::{string::ToString, vec::Vec};
+use std::{collections::BTreeMap, string::ToString};
 
 use alloy_evm::{precompiles::PrecompilesMap, Database};
 use alloy_primitives::{Address, Bytes, TxKind, U256};
@@ -180,19 +180,6 @@ where
     EVM: EvmTr<Context = MegaContext<DB, ExtEnvs>>,
     ERROR: From<DB::Error> + FromStringError,
 {
-    /// Returns the authority nonce from the transaction-local simulated auth-list state.
-    ///
-    /// Used to mirror revm's sequential EIP-7702 auth processing when the same authority appears
-    /// multiple times in one transaction.
-    fn simulated_authority_nonce(
-        simulated_authorities: &[(Address, u64)],
-        authority: Address,
-    ) -> Option<u64> {
-        simulated_authorities.iter().find_map(|(simulated_authority, nonce)| {
-            (*simulated_authority == authority).then_some(*nonce)
-        })
-    }
-
     /// Records REX5 state growth for EIP-7702 authorizations that create authority accounts.
     ///
     /// The scan mirrors revm's auth-list validation order but stops before mutating delegation
@@ -211,7 +198,14 @@ where
         let authority_creations = {
             let (tx, journal) = ctx.tx_journal_mut();
             let mut authority_creations = 0;
-            let mut simulated_authorities = Vec::<(Address, u64)>::new();
+            // Transaction-local simulated auth-list state, mirroring revm's sequential
+            // processing when the same authority appears multiple times in one tx.
+            // A `BTreeMap` keeps per-authorization lookup/update at O(log N) instead of
+            // the O(N) linear scan a `Vec` would need, bounding the whole pass at
+            // O(N log N) (an attacker could otherwise drive O(N²) node CPU with ~1200
+            // unique authorities in one tx). The map is only ever keyed, never iterated for
+            // output, so the produced `authority_creations` count is unchanged.
+            let mut simulated_authorities = BTreeMap::<Address, u64>::new();
             for authorization in tx.authorization_list() {
                 let auth_chain_id = authorization.chain_id();
                 if !auth_chain_id.is_zero() && auth_chain_id != U256::from(chain_id) {
@@ -224,23 +218,22 @@ where
                     continue;
                 };
 
-                let (authority_nonce, creates_authority) = if let Some(nonce) =
-                    Self::simulated_authority_nonce(&simulated_authorities, authority)
-                {
-                    (nonce, false)
-                } else {
-                    let authority_acc = journal.load_account_code(authority)?;
-                    if let Some(bytecode) = &authority_acc.info.code {
-                        if !bytecode.is_empty() && !bytecode.is_eip7702() {
-                            continue;
+                let (authority_nonce, creates_authority) =
+                    if let Some(nonce) = simulated_authorities.get(&authority).copied() {
+                        (nonce, false)
+                    } else {
+                        let authority_acc = journal.load_account_code(authority)?;
+                        if let Some(bytecode) = &authority_acc.info.code {
+                            if !bytecode.is_empty() && !bytecode.is_eip7702() {
+                                continue;
+                            }
                         }
-                    }
-                    (
-                        authority_acc.info.nonce,
-                        authority_acc.is_empty() &&
-                            authority_acc.is_loaded_as_not_existing_not_touched(),
-                    )
-                };
+                        (
+                            authority_acc.info.nonce,
+                            authority_acc.is_empty() &&
+                                authority_acc.is_loaded_as_not_existing_not_touched(),
+                        )
+                    };
 
                 if authorization.nonce() != authority_nonce {
                     continue;
@@ -250,14 +243,9 @@ where
                     authority_creations += 1;
                 }
                 let next_nonce = authority_nonce.saturating_add(1);
-                if let Some((_, nonce)) = simulated_authorities
-                    .iter_mut()
-                    .find(|(simulated_authority, _)| *simulated_authority == authority)
-                {
-                    *nonce = next_nonce;
-                } else {
-                    simulated_authorities.push((authority, next_nonce));
-                }
+                // insert overwrites an existing entry and inserts a new one otherwise,
+                // matching the prior find-or-push.
+                simulated_authorities.insert(authority, next_nonce);
             }
             authority_creations
         };

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -121,7 +121,8 @@ use revm::{
 ///   - Block env opcodes (TIMESTAMP, NUMBER, etc.): `volatile_data_ext::*`
 ///   - BALANCE, EXTCODESIZE, EXTCODECOPY, EXTCODEHASH: `volatile_data_ext::*`
 ///   - SLOAD: `compute_gas_ext::sload`
-///   - SSTORE: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
+///   - SSTORE: `additional_limit_ext` → `compute_gas_ext` (storage-gas charge inlined in
+///     `additional_limit_ext::sstore`)
 ///   - LOG0–LOG4: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
 ///   - CALL: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
 ///   - CREATE, CREATE2: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
@@ -397,7 +398,8 @@ mod mini_rex {
     /// - Most opcodes: `compute_gas_ext::*` (compute gas tracking only)
     /// - Block env opcodes: `volatile_data_ext::*` (gas detention)
     /// - BALANCE, EXTCODESIZE, EXTCODECOPY, EXTCODEHASH: `volatile_data_ext::*` (conditional)
-    /// - SSTORE: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
+    /// - SSTORE: `additional_limit_ext` → `compute_gas_ext` (storage-gas charge inlined in
+    ///   `additional_limit_ext::sstore`)
     /// - LOG0–LOG4: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
     /// - CALL: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
     /// - CREATE, CREATE2: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -1567,6 +1567,8 @@ pub mod storage_gas_ext {
         // installs this wrapper only for REX5+, so pre-REX5 specs never reach here.
         if context.interpreter.runtime_flag.is_static() {
             run_inner_instruction_or_abort!(compute_gas_ext::selfdestruct, context);
+            // Defensive: unreachable in practice — a static SELFDESTRUCT always halts
+            // inside the inner instruction, so the macro returns early above.
             return;
         }
 
@@ -1850,7 +1852,30 @@ pub mod compute_gas_ext {
 
     wrap_op_compute_gas!(revert, "REVERT", instructions::control::revert);
     wrap_op_compute_gas!(invalid, "INVALID", instructions::control::invalid);
-    wrap_op_compute_gas!(selfdestruct, "SELFDESTRUCT", instructions::host::selfdestruct);
+
+    /// `SELFDESTRUCT` opcode with compute gas tracking.
+    ///
+    /// Unlike the default wrapper, the trailing check fans out across all four limit
+    /// dimensions (`record_compute_gas_all_dims`): the REX5 storage wrapper records
+    /// beneficiary data/KV/state usage *before* the inner instruction runs, without
+    /// latching, and those dimensions must latch (and halt) here — only once the inner
+    /// instruction has succeeded. Latching at the recording site instead would stick
+    /// even when the inner instruction subsequently fails and the frame's discardable
+    /// usage is rolled back.
+    pub fn selfdestruct<WIRE: InterpreterTypes, H: HostExt + ?Sized>(
+        context: InstructionContext<'_, H, WIRE>,
+    ) {
+        let gas_before = context.interpreter.gas.remaining();
+
+        // Call the original instruction
+        run_inner_instruction_or_abort!(instructions::host::selfdestruct, context);
+
+        let gas_used = gas_before.saturating_sub(context.interpreter.gas.remaining());
+        let mut additional_limit = context.host.additional_limit().borrow_mut();
+        if !additional_limit.record_compute_gas_all_dims(gas_used) {
+            context.interpreter.halt(additional_limit.exceeding_instruction_result());
+        }
+    }
 }
 
 /// Trait to inspect the stack elements.

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -121,8 +121,7 @@ use revm::{
 ///   - Block env opcodes (TIMESTAMP, NUMBER, etc.): `volatile_data_ext::*`
 ///   - BALANCE, EXTCODESIZE, EXTCODECOPY, EXTCODEHASH: `volatile_data_ext::*`
 ///   - SLOAD: `compute_gas_ext::sload`
-///   - SSTORE: `additional_limit_ext` → `compute_gas_ext` (storage-gas charge inlined in
-///     `additional_limit_ext::sstore`)
+///   - SSTORE: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
 ///   - LOG0–LOG4: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
 ///   - CALL: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
 ///   - CREATE, CREATE2: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
@@ -398,8 +397,7 @@ mod mini_rex {
     /// - Most opcodes: `compute_gas_ext::*` (compute gas tracking only)
     /// - Block env opcodes: `volatile_data_ext::*` (gas detention)
     /// - BALANCE, EXTCODESIZE, EXTCODECOPY, EXTCODEHASH: `volatile_data_ext::*` (conditional)
-    /// - SSTORE: `additional_limit_ext` → `compute_gas_ext` (storage-gas charge inlined in
-    ///   `additional_limit_ext::sstore`)
+    /// - SSTORE: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
     /// - LOG0–LOG4: `additional_limit_ext` → `storage_gas_ext` → `compute_gas_ext`
     /// - CALL: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
     /// - CREATE, CREATE2: `forward_gas_ext` → `storage_gas_ext` → `compute_gas_ext`
@@ -1070,11 +1068,8 @@ pub mod additional_limit_ext {
 
     /// `SSTORE` opcode implementation with data size and KV update limit enforcement.
     ///
-    /// This is the SSTORE entry point. It loads the storage slot once, charges the
-    /// dynamically-scaled storage gas (first-time non-zero write), delegates to
-    /// [`compute_gas_ext::sstore`] for the inner SSTORE + compute-gas tracking, then records data
-    /// size / KV / state-growth usage. The storage-gas charge is inlined here (rather than in a
-    /// separate wrapper layer) so the slot is inspected only once per SSTORE.
+    /// This wrapper adds limit tracking on top of [`storage_gas_ext::sstore`], which handles
+    /// compute gas tracking and storage gas costs.
     ///
     /// # Data Size and KV Update Tracking
     ///
@@ -1113,31 +1108,8 @@ pub mod additional_limit_ext {
         };
         let loaded_data = SStoreResult { original_value, present_value, new_value };
 
-        // Charge dynamically-scaled storage gas before the instruction executes (only when first
-        // writing a non-zero value to an originally-zero slot). This was previously done in a
-        // separate `storage_gas_ext::sstore` wrapper layer that re-loaded the same slot via a
-        // second `inspect_storage`; the charge is inlined here to reuse the slot already loaded
-        // above, eliminating the redundant per-SSTORE inspection. Behavior is identical: the
-        // first-time-write decision uses the same pre-execution `original`/`present` values, the
-        // charge happens at the same point (before the inner SSTORE runs), and REX5 still drains
-        // the storage stipend allowance first (pre-REX5 returns 0).
-        if original_value.is_zero() && present_value.is_zero() && !new_value.is_zero() {
-            let Some(sstore_set_storage_gas) =
-                context.host.sstore_set_storage_gas(target_address, index)
-            else {
-                context.interpreter.halt(InstructionResult::FatalExternalError);
-                return;
-            };
-            let drained = context
-                .host
-                .additional_limit()
-                .borrow_mut()
-                .try_consume_storage_stipend(sstore_set_storage_gas);
-            gas!(context.interpreter, sstore_set_storage_gas - drained);
-        }
-
-        // Execute the original SSTORE instruction (compute-gas tracking layer).
-        run_inner_instruction_or_abort!(compute_gas_ext::sstore, context);
+        // Execute the original SSTORE instruction
+        run_inner_instruction_or_abort!(storage_gas_ext::sstore, context);
 
         // KV update bomb and data bomb (only when first writing non-zero value to originally zero
         // slot): check if the number of key-value updates or the total data size will exceed the
@@ -1534,6 +1506,67 @@ pub mod storage_gas_ext {
                 context.interpreter.halt(InstructionResult::InvalidFEOpcode);
             }
         }
+    }
+
+    /// `SSTORE` opcode implementation modified from `revm` with compute gas tracking and
+    /// dynamically-scaled storage gas costs.
+    ///
+    /// # Differences from the standard EVM
+    ///
+    /// 1. **Dynamic Storage Gas**: Additional storage gas ONLY when setting originally-zero slot to
+    ///    non-zero:
+    ///    - Base cost 2,000,000 gas, multiplied by `bucket_capacity / MIN_BUCKET_SIZE`
+    ///    - Not charged for updating already-non-zero slots or resetting to zero
+    ///
+    /// # Assumptions
+    ///
+    /// This alternative implementation of `SSTORE` is only used when the `MINI_REX` spec is
+    /// enabled, so we can safely assume that all features before and including Mini-Rex are
+    /// enabled.
+    pub fn sstore<
+        WIRE: InterpreterTypes<Stack: StackInspectTr>,
+        H: HostExt + ContextTr + JournalInspectTr + ?Sized,
+    >(
+        context: InstructionContext<'_, H, WIRE>,
+    ) {
+        // The address to the underlying execution contract state
+        let target_address = context.interpreter.input.target_address();
+        // The storage slot to write
+        let Some(index) = context.interpreter.stack.inspect::<0>() else {
+            context.interpreter.halt(InstructionResult::StackUnderflow);
+            return;
+        };
+        // The storage slot values
+        let mega_spec = context.host.spec_id();
+        let Ok(slot) = context.host.inspect_storage(mega_spec, target_address, index) else {
+            context.interpreter.halt(InstructionResult::FatalExternalError);
+            return;
+        };
+        let (original_value, present_value) = (slot.original_value(), slot.present_value());
+        let Some(new_value) = context.interpreter.stack.inspect::<1>() else {
+            context.interpreter.halt(InstructionResult::StackUnderflow);
+            return;
+        };
+
+        // Charge storage gas cost before the instruction is executed.
+        // REX5 drains the storage stipend allowance first; pre-REX5 returns 0.
+        if original_value.is_zero() && present_value.is_zero() && !new_value.is_zero() {
+            let Some(sstore_set_storage_gas) =
+                context.host.sstore_set_storage_gas(target_address, index)
+            else {
+                context.interpreter.halt(InstructionResult::FatalExternalError);
+                return;
+            };
+            let drained = context
+                .host
+                .additional_limit()
+                .borrow_mut()
+                .try_consume_storage_stipend(sstore_set_storage_gas);
+            gas!(context.interpreter, sstore_set_storage_gas - drained);
+        }
+
+        // Execute the original SSTORE instruction
+        run_inner_instruction_or_abort!(compute_gas_ext::sstore, context);
     }
 
     /// `SELFDESTRUCT` opcode implementation with storage gas metering for

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -1068,8 +1068,11 @@ pub mod additional_limit_ext {
 
     /// `SSTORE` opcode implementation with data size and KV update limit enforcement.
     ///
-    /// This wrapper adds limit tracking on top of [`storage_gas_ext::sstore`], which handles
-    /// compute gas tracking and storage gas costs.
+    /// This is the SSTORE entry point. It loads the storage slot once, charges the
+    /// dynamically-scaled storage gas (first-time non-zero write), delegates to
+    /// [`compute_gas_ext::sstore`] for the inner SSTORE + compute-gas tracking, then records data
+    /// size / KV / state-growth usage. The storage-gas charge is inlined here (rather than in a
+    /// separate wrapper layer) so the slot is inspected only once per SSTORE.
     ///
     /// # Data Size and KV Update Tracking
     ///
@@ -1108,8 +1111,31 @@ pub mod additional_limit_ext {
         };
         let loaded_data = SStoreResult { original_value, present_value, new_value };
 
-        // Execute the original SSTORE instruction
-        run_inner_instruction_or_abort!(storage_gas_ext::sstore, context);
+        // Charge dynamically-scaled storage gas before the instruction executes (only when first
+        // writing a non-zero value to an originally-zero slot). This was previously done in a
+        // separate `storage_gas_ext::sstore` wrapper layer that re-loaded the same slot via a
+        // second `inspect_storage`; the charge is inlined here to reuse the slot already loaded
+        // above, eliminating the redundant per-SSTORE inspection. Behavior is identical: the
+        // first-time-write decision uses the same pre-execution `original`/`present` values, the
+        // charge happens at the same point (before the inner SSTORE runs), and REX5 still drains
+        // the storage stipend allowance first (pre-REX5 returns 0).
+        if original_value.is_zero() && present_value.is_zero() && !new_value.is_zero() {
+            let Some(sstore_set_storage_gas) =
+                context.host.sstore_set_storage_gas(target_address, index)
+            else {
+                context.interpreter.halt(InstructionResult::FatalExternalError);
+                return;
+            };
+            let drained = context
+                .host
+                .additional_limit()
+                .borrow_mut()
+                .try_consume_storage_stipend(sstore_set_storage_gas);
+            gas!(context.interpreter, sstore_set_storage_gas - drained);
+        }
+
+        // Execute the original SSTORE instruction (compute-gas tracking layer).
+        run_inner_instruction_or_abort!(compute_gas_ext::sstore, context);
 
         // KV update bomb and data bomb (only when first writing non-zero value to originally zero
         // slot): check if the number of key-value updates or the total data size will exceed the
@@ -1508,67 +1534,6 @@ pub mod storage_gas_ext {
         }
     }
 
-    /// `SSTORE` opcode implementation modified from `revm` with compute gas tracking and
-    /// dynamically-scaled storage gas costs.
-    ///
-    /// # Differences from the standard EVM
-    ///
-    /// 1. **Dynamic Storage Gas**: Additional storage gas ONLY when setting originally-zero slot to
-    ///    non-zero:
-    ///    - Base cost 2,000,000 gas, multiplied by `bucket_capacity / MIN_BUCKET_SIZE`
-    ///    - Not charged for updating already-non-zero slots or resetting to zero
-    ///
-    /// # Assumptions
-    ///
-    /// This alternative implementation of `SSTORE` is only used when the `MINI_REX` spec is
-    /// enabled, so we can safely assume that all features before and including Mini-Rex are
-    /// enabled.
-    pub fn sstore<
-        WIRE: InterpreterTypes<Stack: StackInspectTr>,
-        H: HostExt + ContextTr + JournalInspectTr + ?Sized,
-    >(
-        context: InstructionContext<'_, H, WIRE>,
-    ) {
-        // The address to the underlying execution contract state
-        let target_address = context.interpreter.input.target_address();
-        // The storage slot to write
-        let Some(index) = context.interpreter.stack.inspect::<0>() else {
-            context.interpreter.halt(InstructionResult::StackUnderflow);
-            return;
-        };
-        // The storage slot values
-        let mega_spec = context.host.spec_id();
-        let Ok(slot) = context.host.inspect_storage(mega_spec, target_address, index) else {
-            context.interpreter.halt(InstructionResult::FatalExternalError);
-            return;
-        };
-        let (original_value, present_value) = (slot.original_value(), slot.present_value());
-        let Some(new_value) = context.interpreter.stack.inspect::<1>() else {
-            context.interpreter.halt(InstructionResult::StackUnderflow);
-            return;
-        };
-
-        // Charge storage gas cost before the instruction is executed.
-        // REX5 drains the storage stipend allowance first; pre-REX5 returns 0.
-        if original_value.is_zero() && present_value.is_zero() && !new_value.is_zero() {
-            let Some(sstore_set_storage_gas) =
-                context.host.sstore_set_storage_gas(target_address, index)
-            else {
-                context.interpreter.halt(InstructionResult::FatalExternalError);
-                return;
-            };
-            let drained = context
-                .host
-                .additional_limit()
-                .borrow_mut()
-                .try_consume_storage_stipend(sstore_set_storage_gas);
-            gas!(context.interpreter, sstore_set_storage_gas - drained);
-        }
-
-        // Execute the original SSTORE instruction
-        run_inner_instruction_or_abort!(compute_gas_ext::sstore, context);
-    }
-
     /// `SELFDESTRUCT` opcode implementation with storage gas metering for
     /// new beneficiary account creation (REX5+).
     ///
@@ -1590,6 +1555,19 @@ pub mod storage_gas_ext {
     >(
         context: InstructionContext<'_, H, WIRE>,
     ) {
+        // Inside a static frame, revm's inner SELFDESTRUCT halts on the
+        // static-context check without changing state. Skip the mega host work below
+        // (two account inspections, SALT account-creation pricing, the storage-gas
+        // stipend draw and tracker write) — the frame reverts and discards all of it
+        // anyway — and let the inner instruction produce the identical halt. This is
+        // behavior-neutral: the static halt is exceptional, so the frame's gas and
+        // tracked usage are the same whether or not the host work ran first. The table
+        // installs this wrapper only for REX5+, so pre-REX5 specs never reach here.
+        if context.interpreter.runtime_flag.is_static() {
+            run_inner_instruction_or_abort!(compute_gas_ext::selfdestruct, context);
+            return;
+        }
+
         let eth_spec = context.interpreter.runtime_flag.spec_id();
 
         // Peek beneficiary address from stack (SELFDESTRUCT uses stack position 0)
@@ -1640,8 +1618,33 @@ pub mod compute_gas_ext {
     use super::*;
 
     /// Macro to wrap the original instruction implementation with compute gas tracking.
+    ///
+    /// Two variants:
+    /// - default: "simple" opcodes that can never spawn a child frame. The compute gas used is
+    ///   simply `gas_before - gas_after`. These opcodes never set an `InterpreterAction::NewFrame`,
+    ///   so the child-gas-subtraction match (below) would always fall through to `_` — it is
+    ///   omitted entirely to keep the per-opcode hot path lean.
+    /// - `@frame`: the call/create family (`CALL`/`CALLCODE`/`DELEGATECALL`/`STATICCALL`/
+    ///   `CREATE`/`CREATE2`), the only opcodes that set `NewFrame`. These must subtract the gas
+    ///   forwarded to the child frame so the parent's compute gas is not over-counted.
     macro_rules! wrap_op_compute_gas {
         ($fn_name:ident, $opcode_name:expr, $original_fn:path) => {
+            #[doc = concat!("`", $opcode_name, "` opcode with compute gas tracking.")]
+            #[inline]
+            pub fn $fn_name<WIRE: InterpreterTypes, H: HostExt + ?Sized>(
+                context: InstructionContext<'_, H, WIRE>,
+            ) {
+                let gas_before = context.interpreter.gas.remaining();
+
+                // Call the original instruction
+                run_inner_instruction_or_abort!($original_fn, context);
+
+                let gas_used = gas_before.saturating_sub(context.interpreter.gas.remaining());
+                let mut additional_limit = context.host.additional_limit().borrow_mut();
+                compute_gas!(context.interpreter, additional_limit, gas_used);
+            }
+        };
+        (@frame $fn_name:ident, $opcode_name:expr, $original_fn:path) => {
             #[doc = concat!("`", $opcode_name, "` opcode with compute gas tracking.")]
             #[inline]
             pub fn $fn_name<WIRE: InterpreterTypes, H: HostExt + ?Sized>(
@@ -1835,13 +1838,13 @@ pub mod compute_gas_ext {
     wrap_op_compute_gas!(log3, "LOG3", instructions::host::log::<3, _>);
     wrap_op_compute_gas!(log4, "LOG4", instructions::host::log::<4, _>);
 
-    wrap_op_compute_gas!(create, "CREATE", instructions::contract::create::<_, false, _>);
-    wrap_op_compute_gas!(call, "CALL", instructions::contract::call);
-    wrap_op_compute_gas!(call_code, "CALLCODE", instructions::contract::call_code);
+    wrap_op_compute_gas!(@frame create, "CREATE", instructions::contract::create::<_, false, _>);
+    wrap_op_compute_gas!(@frame call, "CALL", instructions::contract::call);
+    wrap_op_compute_gas!(@frame call_code, "CALLCODE", instructions::contract::call_code);
     wrap_op_compute_gas!(ret, "RETURN", instructions::control::ret);
-    wrap_op_compute_gas!(delegate_call, "DELEGATECALL", instructions::contract::delegate_call);
-    wrap_op_compute_gas!(create2, "CREATE2", instructions::contract::create::<_, true, _>);
-    wrap_op_compute_gas!(static_call, "STATICCALL", instructions::contract::static_call);
+    wrap_op_compute_gas!(@frame delegate_call, "DELEGATECALL", instructions::contract::delegate_call);
+    wrap_op_compute_gas!(@frame create2, "CREATE2", instructions::contract::create::<_, true, _>);
+    wrap_op_compute_gas!(@frame static_call, "STATICCALL", instructions::contract::static_call);
 
     wrap_op_compute_gas!(revert, "REVERT", instructions::control::revert);
     wrap_op_compute_gas!(invalid, "INVALID", instructions::control::invalid);

--- a/crates/mega-evm/src/limit/compute_gas.rs
+++ b/crates/mega-evm/src/limit/compute_gas.rs
@@ -139,6 +139,7 @@ impl ComputeGasTracker {
     /// records to the `tx_entry`.
     ///
     /// Compute gas is always persistent because CPU cycles cannot be undone.
+    #[inline]
     pub(crate) fn record_gas_used(&mut self, gas: u64) {
         if !self.frame_tracker.add_frame_persistent(gas) {
             self.frame_tracker.add_tx_persistent(gas);

--- a/crates/mega-evm/src/limit/limit.rs
+++ b/crates/mega-evm/src/limit/limit.rs
@@ -369,6 +369,20 @@ impl AdditionalLimit {
         // usage for transactions halted on a non-compute dimension (e.g. intrinsic data size
         // latched in `before_tx_start` before `validate` records the initial gas).
         self.compute_gas.record_gas_used(compute_gas_used);
+        // Debug-only guard for the latch protocol: the compute-only fast path below is sound
+        // only if every non-compute mutation site already latched its own exceed. If a
+        // non-compute dimension is over limit but not yet latched, some mutation site is missing
+        // its `check_limit()` — catch it here in tests, not in production. The sub-tracker
+        // `check_limit()` calls are non-mutating, so this compiles out of release builds. (The
+        // one pre-inner recorder, SELFDESTRUCT, routes through `record_compute_gas_all_dims`, not
+        // this method, so it never trips this.)
+        debug_assert!(
+            self.has_exceeded_limit.exceeded_limit() ||
+                (!self.data_size.check_limit().exceeded_limit() &&
+                    !self.kv_update.check_limit().exceeded_limit() &&
+                    !self.state_growth.check_limit().exceeded_limit()),
+            "non-compute limit exceeded without latching: a mutation site is missing check_limit()",
+        );
         // If any dimension was already latched as exceeded, surface it immediately (matches the
         // leading short-circuit in `check_limit`).
         if self.has_exceeded_limit.exceeded_limit() {

--- a/crates/mega-evm/src/limit/limit.rs
+++ b/crates/mega-evm/src/limit/limit.rs
@@ -363,6 +363,12 @@ impl AdditionalLimit {
     /// wrapper, removing a call across the `RefMut<AdditionalLimit>` boundary.
     #[inline]
     pub(crate) fn record_compute_gas(&mut self, compute_gas_used: u64) -> bool {
+        // Record unconditionally, even when another dimension has already latched an exceed:
+        // the compute work was performed, and the recorded total feeds the transaction outcome
+        // and block-level compute accounting. Skipping the record would under-report compute
+        // usage for transactions halted on a non-compute dimension (e.g. intrinsic data size
+        // latched in `before_tx_start` before `validate` records the initial gas).
+        self.compute_gas.record_gas_used(compute_gas_used);
         // If any dimension was already latched as exceeded, surface it immediately (matches the
         // leading short-circuit in `check_limit`).
         if self.has_exceeded_limit.exceeded_limit() {
@@ -375,7 +381,6 @@ impl AdditionalLimit {
         // `record_oracle_hint_bytes`, `on_selfdestruct_new_account`, the frame-lifecycle hooks),
         // each of which runs `check_limit()` itself and latches any exceed into
         // `has_exceeded_limit` — which the short-circuit above then surfaces here.
-        self.compute_gas.record_gas_used(compute_gas_used);
         let check = self.compute_gas.check_limit();
         if check.exceeded_limit() {
             self.has_exceeded_limit = check;
@@ -849,5 +854,73 @@ pub(crate) fn mark_frame_result_as_exceeding_limit(
                 output,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use revm::context::tx::TxEnvBuilder;
+
+    use super::{super::LimitKind, *};
+
+    fn test_limits() -> EvmTxRuntimeLimits {
+        EvmTxRuntimeLimits {
+            tx_data_size_limit: 100,
+            tx_kv_updates_limit: 1_000,
+            tx_compute_gas_limit: 1_000_000,
+            tx_state_growth_limit: 1_000,
+            block_env_access_compute_gas_limit: 1_000_000,
+            oracle_access_compute_gas_limit: 1_000_000,
+        }
+    }
+
+    /// Compute gas must be recorded even when another dimension has already latched an
+    /// exceed: the work was performed, and the recorded total feeds the transaction outcome
+    /// and block-level compute accounting. A skipped record would under-report compute usage
+    /// for transactions halted on a non-compute dimension.
+    ///
+    /// This pins the `validate()` path: `before_tx_start` latches intrinsic data-size
+    /// overflow before any frame exists, then the initial gas is recorded.
+    #[test]
+    fn test_record_compute_gas_records_after_other_dimension_latched() {
+        let mut limit = AdditionalLimit::new(MegaSpecId::REX5, test_limits());
+
+        // Latch the data-size dimension at its mutation site: intrinsic transaction data
+        // (110-byte base + 200 bytes of calldata) exceeds the 100-byte limit.
+        let tx = MegaTransaction::new(
+            TxEnvBuilder::new()
+                .caller(Address::ZERO)
+                .call(Address::ZERO)
+                .data(vec![0u8; 200].into())
+                .build_fill(),
+        );
+        limit.before_tx_start(&tx);
+        assert!(
+            matches!(
+                limit.has_exceeded_limit,
+                LimitCheck::ExceedsLimit { kind: LimitKind::DataSize, .. }
+            ),
+            "data-size exceed should be latched, got {:?}",
+            limit.has_exceeded_limit,
+        );
+
+        // The trailing compute-gas record of the same opcode must still surface the latched
+        // exceed AND record the gas.
+        assert!(!limit.record_compute_gas(5_000), "latched exceed must surface as false");
+        assert_eq!(
+            limit.get_usage().compute_gas,
+            5_000,
+            "compute gas must be recorded even after another dimension latched",
+        );
+
+        // The latched kind is preserved (not overwritten by the compute-gas check).
+        assert!(
+            matches!(
+                limit.has_exceeded_limit,
+                LimitCheck::ExceedsLimit { kind: LimitKind::DataSize, .. }
+            ),
+            "latched kind must remain DataSize, got {:?}",
+            limit.has_exceeded_limit,
+        );
     }
 }

--- a/crates/mega-evm/src/limit/limit.rs
+++ b/crates/mega-evm/src/limit/limit.rs
@@ -357,10 +357,31 @@ impl AdditionalLimit {
 /* Hooks for transaction execution lifecycle. */
 impl AdditionalLimit {
     /// Records the compute gas used and returns `false` if the limit has been exceeded.
+    ///
+    /// This runs on every metered opcode, so it is the hottest hook in the whole tracker.
+    /// `#[inline]` lets the record + within-limit check fold directly into the per-opcode
+    /// wrapper, removing a call across the `RefMut<AdditionalLimit>` boundary.
+    #[inline]
     pub(crate) fn record_compute_gas(&mut self, compute_gas_used: u64) -> bool {
+        // If any dimension was already latched as exceeded, surface it immediately (matches the
+        // leading short-circuit in `check_limit`).
+        if self.has_exceeded_limit.exceeded_limit() {
+            return false;
+        }
+        // Recording compute gas can only change the compute-gas dimension, so check just that one
+        // (`compute_gas.check_limit()` covers both the Rex4+ per-frame budget and the TX-level
+        // detained limit) instead of fanning out to all four sub-trackers. The other three
+        // dimensions only change at their own mutation sites (`on_sstore`, `on_log`,
+        // `record_oracle_hint_bytes`, `on_selfdestruct_new_account`, the frame-lifecycle hooks),
+        // each of which runs `check_limit()` itself and latches any exceed into
+        // `has_exceeded_limit` — which the short-circuit above then surfaces here.
         self.compute_gas.record_gas_used(compute_gas_used);
-
-        !self.check_limit().exceeded_limit()
+        let check = self.compute_gas.check_limit();
+        if check.exceeded_limit() {
+            self.has_exceeded_limit = check;
+            return false;
+        }
+        true
     }
 
     /// Records the current frame's remaining gas on a TX-level limit exceed so it can be
@@ -747,6 +768,13 @@ impl AdditionalLimit {
         self.data_size.record_account_write();
         self.kv_update.record_account_update();
         self.state_growth.record_growth(1);
+
+        // Latch any resulting data-size/KV/state-growth exceed into `has_exceeded_limit`.
+        // The SELFDESTRUCT wrapper's trailing `compute_gas!` goes through `record_compute_gas`,
+        // which only checks the compute-gas dimension and would otherwise not re-examine these
+        // three; latching here keeps the exceed visible at the same opcode, matching the prior
+        // behavior where the per-opcode check fanned out to all four dimensions.
+        let _ = self.check_limit();
     }
 }
 

--- a/crates/mega-evm/src/limit/limit.rs
+++ b/crates/mega-evm/src/limit/limit.rs
@@ -389,6 +389,21 @@ impl AdditionalLimit {
         true
     }
 
+    /// Records the compute gas used and checks ALL four limit dimensions (the
+    /// pre-optimization fan-out), returning `false` if any has been exceeded.
+    ///
+    /// Retained for SELFDESTRUCT: its REX5 storage wrapper records beneficiary
+    /// data/KV/state usage *before* the inner instruction runs, without latching
+    /// (the inner instruction may still fail, in which case the frame pops that
+    /// discardable usage). The fan-out here latches those dimensions only after the
+    /// inner instruction has succeeded, with `check_limit`'s dimension priority.
+    /// Hot-path opcodes use [`Self::record_compute_gas`] instead.
+    #[inline]
+    pub(crate) fn record_compute_gas_all_dims(&mut self, compute_gas_used: u64) -> bool {
+        self.compute_gas.record_gas_used(compute_gas_used);
+        !self.check_limit().exceeded_limit()
+    }
+
     /// Records the current frame's remaining gas on a TX-level limit exceed so it can be
     /// refunded to the sender. The storage-stipend tracker decides how `gas.remaining()`
     /// maps to the refundable balance — see
@@ -774,12 +789,11 @@ impl AdditionalLimit {
         self.kv_update.record_account_update();
         self.state_growth.record_growth(1);
 
-        // Latch any resulting data-size/KV/state-growth exceed into `has_exceeded_limit`.
-        // The SELFDESTRUCT wrapper's trailing `compute_gas!` goes through `record_compute_gas`,
-        // which only checks the compute-gas dimension and would otherwise not re-examine these
-        // three; latching here keeps the exceed visible at the same opcode, matching the prior
-        // behavior where the per-opcode check fanned out to all four dimensions.
-        let _ = self.check_limit();
+        // Deliberately no latch here: this runs *before* the inner SELFDESTRUCT executes,
+        // which may still fail (e.g. out of gas on the cold beneficiary load, or a DB
+        // error) — the frame then pops this discardable usage, and a latch taken now would
+        // stick and misattribute the failure. The trailing `record_compute_gas_all_dims`
+        // in `compute_gas_ext::selfdestruct` latches these dimensions after inner success.
     }
 }
 
@@ -874,6 +888,14 @@ mod tests {
         }
     }
 
+    /// Returns the latched limit kind, or `None` when within limit.
+    fn latched_kind(limit: &AdditionalLimit) -> Option<LimitKind> {
+        match limit.has_exceeded_limit {
+            LimitCheck::ExceedsLimit { kind, .. } => Some(kind),
+            LimitCheck::WithinLimit => None,
+        }
+    }
+
     /// Compute gas must be recorded even when another dimension has already latched an
     /// exceed: the work was performed, and the recorded total feeds the transaction outcome
     /// and block-level compute accounting. A skipped record would under-report compute usage
@@ -895,14 +917,7 @@ mod tests {
                 .build_fill(),
         );
         limit.before_tx_start(&tx);
-        assert!(
-            matches!(
-                limit.has_exceeded_limit,
-                LimitCheck::ExceedsLimit { kind: LimitKind::DataSize, .. }
-            ),
-            "data-size exceed should be latched, got {:?}",
-            limit.has_exceeded_limit,
-        );
+        assert_eq!(latched_kind(&limit), Some(LimitKind::DataSize));
 
         // The trailing compute-gas record of the same opcode must still surface the latched
         // exceed AND record the gas.
@@ -914,13 +929,29 @@ mod tests {
         );
 
         // The latched kind is preserved (not overwritten by the compute-gas check).
-        assert!(
-            matches!(
-                limit.has_exceeded_limit,
-                LimitCheck::ExceedsLimit { kind: LimitKind::DataSize, .. }
-            ),
-            "latched kind must remain DataSize, got {:?}",
-            limit.has_exceeded_limit,
-        );
+        assert_eq!(latched_kind(&limit), Some(LimitKind::DataSize));
+    }
+
+    /// SELFDESTRUCT's beneficiary usage is recorded *before* the inner instruction runs and
+    /// must NOT latch at the recording site: the inner instruction can still fail (out of
+    /// gas, DB error), in which case the frame pops the discardable usage and a latch taken
+    /// at recording time would stick and misattribute the failure. The latch belongs to the
+    /// trailing all-dimension check, which only runs after the inner instruction succeeds.
+    #[test]
+    fn test_selfdestruct_usage_latches_only_at_trailing_check() {
+        let mut limits = test_limits();
+        // Below the 40-byte account-info write, so the beneficiary creation exceeds it.
+        limits.tx_data_size_limit = 10;
+        let mut limit = AdditionalLimit::new(MegaSpecId::REX5, limits);
+        // Simulate an active call frame (SELFDESTRUCT always runs inside one).
+        limit.push_empty_frame();
+
+        // Recording site: usage recorded, but no latch yet (inner instruction may still fail).
+        limit.on_selfdestruct_new_account();
+        assert_eq!(latched_kind(&limit), None, "recording site must not latch");
+
+        // Trailing all-dimension check (runs only after inner success): latches and halts.
+        assert!(!limit.record_compute_gas_all_dims(100), "trailing check must surface exceed");
+        assert_eq!(latched_kind(&limit), Some(LimitKind::DataSize));
     }
 }

--- a/crates/mega-evm/tests/rex5/main.rs
+++ b/crates/mega-evm/tests/rex5/main.rs
@@ -24,5 +24,6 @@ mod pre_block_system_calls;
 mod precompile_compute_gas;
 mod sandbox_accounting;
 mod selfdestruct_beneficiary;
+mod sstore_storage_gas_error;
 mod stipend_accounting;
 mod system_tx_replay;

--- a/crates/mega-evm/tests/rex5/selfdestruct_beneficiary.rs
+++ b/crates/mega-evm/tests/rex5/selfdestruct_beneficiary.rs
@@ -9,8 +9,8 @@ use alloy_primitives::{address, Address, Bytes, U256};
 use alloy_sol_types::{SolCall, SolError};
 use mega_evm::{
     test_utils::{BytecodeBuilder, MemoryDatabase},
-    IMegaAccessControl, LimitUsage, MegaContext, MegaEvm, MegaHaltReason, MegaSpecId,
-    MegaTransaction, VolatileDataAccessType, ACCESS_CONTROL_ADDRESS,
+    EvmTxRuntimeLimits, IMegaAccessControl, LimitUsage, MegaContext, MegaEvm, MegaHaltReason,
+    MegaSpecId, MegaTransaction, VolatileDataAccessType, ACCESS_CONTROL_ADDRESS,
 };
 use revm::{
     bytecode::opcode::*,
@@ -425,4 +425,52 @@ fn test_rex5_selfdestruct_in_staticcall_leaks_no_usage() {
     let (sd_res_rex4, sd_usage_rex4) = run(MegaSpecId::REX4, sd_child);
     assert!(sd_res_rex4.result.is_success(), "rex4 parent tx should succeed");
     assert_eq!(sd_usage_rex4.state_growth, 0, "rex4 static SELFDESTRUCT must not grow state");
+}
+
+/// SELFDESTRUCT whose beneficiary creation exceeds the state-growth budget must fail at
+/// the SELFDESTRUCT itself via the trailing all-dimension check: the usage is recorded
+/// before the inner instruction runs, but only latched once the inner instruction has
+/// succeeded.
+#[test]
+fn test_rex5_selfdestruct_beneficiary_creation_fails_on_state_growth_limit() {
+    let sd_code =
+        BytecodeBuilder::default().push_address(EMPTY_BENEFICIARY).append(SELFDESTRUCT).build();
+
+    let run = |growth_limit: u64| {
+        let mut db = MemoryDatabase::default()
+            .account_code(CONTRACT, sd_code.clone())
+            .account_balance(CONTRACT, U256::from(1_000u64))
+            .account_balance(CALLER, U256::from(10).pow(U256::from(18)));
+        let mut context = MegaContext::new(&mut db, MegaSpecId::REX5).with_tx_runtime_limits(
+            EvmTxRuntimeLimits::no_limits().with_tx_state_growth_limit(growth_limit),
+        );
+        context.modify_chain(|chain| {
+            chain.operator_fee_scalar = Some(U256::from(0));
+            chain.operator_fee_constant = Some(U256::from(0));
+        });
+        let mut evm = MegaEvm::new(context);
+        let tx = TxEnvBuilder::default()
+            .caller(CALLER)
+            .call(CONTRACT)
+            .gas_limit(10_000_000)
+            .build_fill();
+        let mut tx = MegaTransaction::new(tx);
+        tx.enveloped_tx = Some(Bytes::new());
+        let r = alloy_evm::Evm::transact_raw(&mut evm, tx).unwrap();
+        let usage = evm.ctx_ref().additional_limit.borrow().get_usage();
+        (r, usage)
+    };
+
+    // Control: a budget of 1 admits the single new beneficiary account.
+    let (ok_res, ok_usage) = run(1);
+    assert!(ok_res.result.is_success(), "control should succeed: {:?}", ok_res.result);
+    assert_eq!(ok_usage.state_growth, 1, "beneficiary creation should count as growth");
+
+    // Budget 0: the beneficiary creation trips the limit at the SELFDESTRUCT.
+    let (res, _) = run(0);
+    assert!(
+        !res.result.is_success(),
+        "zero state-growth budget must fail the SELFDESTRUCT, got {:?}",
+        res.result,
+    );
 }

--- a/crates/mega-evm/tests/rex5/selfdestruct_beneficiary.rs
+++ b/crates/mega-evm/tests/rex5/selfdestruct_beneficiary.rs
@@ -348,3 +348,81 @@ fn test_rex5_selfdestruct_to_beneficiary_without_volatile_disabled() {
         usage.state_growth,
     );
 }
+
+// ============================================================================
+// SELFDESTRUCT attempted inside a STATICCALL frame
+// ============================================================================
+
+/// A parent that STATICCALLs `target` once (forwarding `gas_each`), discards the
+/// result, and STOPs successfully.
+fn staticcall_once_parent(target: Address, gas_each: u64) -> Bytes {
+    BytecodeBuilder::default()
+        .push_number(0u64) // retSize
+        .push_number(0u64) // retOffset
+        .push_number(0u64) // argsSize
+        .push_number(0u64) // argsOffset
+        .push_address(target)
+        .push_number(gas_each) // forwarded gas (top of stack)
+        .append(STATICCALL)
+        .append(POP)
+        .append(STOP)
+        .build()
+}
+
+/// SELFDESTRUCT attempted inside a STATICCALL frame must halt on revm's
+/// static-context check and leak NO resource usage for the (reverted)
+/// beneficiary creation. The `is_static` early-exit guard in
+/// `storage_gas_ext::selfdestruct` skips the host work; the frame revert would
+/// discard it regardless, so the tracked usage is identical to a STATICCALL that
+/// merely STOPs — and specifically records zero state growth even though the
+/// child is funded and the beneficiary is empty (the value branch that would
+/// charge new-account creation never commits).
+#[test]
+fn test_rex5_selfdestruct_in_staticcall_leaks_no_usage() {
+    let gas_each = 200_000u64;
+    let parent_code = staticcall_once_parent(CONTRACT, gas_each);
+    let sd_child =
+        BytecodeBuilder::default().push_address(EMPTY_BENEFICIARY).append(SELFDESTRUCT).build();
+    let stop_child = BytecodeBuilder::default().append(STOP).build();
+
+    let run = |spec: MegaSpecId, child: Bytes| {
+        let mut db = MemoryDatabase::default()
+            .account_code(PARENT, parent_code.clone())
+            .account_code(CONTRACT, child)
+            // fund the child so the SELFDESTRUCT has_value / SALT branch would trigger
+            .account_balance(CONTRACT, U256::from(1_000u64))
+            .account_balance(CALLER, U256::from(10).pow(U256::from(18)));
+        let tx =
+            TxEnvBuilder::default().caller(CALLER).call(PARENT).gas_limit(10_000_000).build_fill();
+        transact(spec, &mut db, tx)
+    };
+
+    let (sd_res, sd_usage) = run(MegaSpecId::REX5, sd_child.clone());
+    let (stop_res, stop_usage) = run(MegaSpecId::REX5, stop_child);
+
+    // The parent swallows the inner STATICCALL failure and completes.
+    assert!(sd_res.result.is_success(), "parent tx should succeed: {:?}", sd_res.result);
+    assert!(stop_res.result.is_success(), "control tx should succeed: {:?}", stop_res.result);
+
+    // No beneficiary creation leaks into committed usage: identical to the STOP
+    // control on every lane, and zero state growth.
+    assert_eq!(
+        sd_usage.state_growth, stop_usage.state_growth,
+        "static SELFDESTRUCT leaked state growth vs STOP control",
+    );
+    assert_eq!(
+        sd_usage.kv_updates, stop_usage.kv_updates,
+        "static SELFDESTRUCT leaked KV updates vs STOP control",
+    );
+    assert_eq!(
+        sd_usage.data_size, stop_usage.data_size,
+        "static SELFDESTRUCT leaked data size vs STOP control",
+    );
+    assert_eq!(sd_usage.state_growth, 0, "no beneficiary account should be created");
+
+    // Pre-REX5 control: the same scenario under REX4 also completes with no
+    // leaked growth, confirming the REX5 guard did not diverge the two specs.
+    let (sd_res_rex4, sd_usage_rex4) = run(MegaSpecId::REX4, sd_child);
+    assert!(sd_res_rex4.result.is_success(), "rex4 parent tx should succeed");
+    assert_eq!(sd_usage_rex4.state_growth, 0, "rex4 static SELFDESTRUCT must not grow state");
+}

--- a/crates/mega-evm/tests/rex5/sstore_storage_gas_error.rs
+++ b/crates/mega-evm/tests/rex5/sstore_storage_gas_error.rs
@@ -1,0 +1,103 @@
+//! SSTORE storage-gas pricing error path.
+//!
+//! The dynamically-scaled storage gas for a first-time non-zero write is charged inline
+//! in `additional_limit_ext::sstore`, before the inner SSTORE executes. When the SALT
+//! environment fails to price the slot (`sstore_set_storage_gas` returns `None`), the
+//! instruction must halt with `FatalExternalError`, which surfaces as `EVMError::Custom`.
+
+use std::convert::Infallible;
+
+use alloy_primitives::{address, Address, Bytes, TxKind, U256};
+use mega_evm::{
+    test_utils::{BytecodeBuilder, MemoryDatabase},
+    BucketId, EVMError, EmptyExternalEnv, EvmTxRuntimeLimits, ExternalEnvs, MegaContext, MegaEvm,
+    MegaHaltReason, MegaSpecId, MegaTransaction, MegaTransactionError, SaltEnv,
+};
+use revm::{
+    bytecode::opcode::{SSTORE, STOP},
+    context::{result::ResultAndState, TxEnv},
+};
+
+const CALLER: Address = address!("2000000000000000000000000000000000000011");
+const CONTRACT: Address = address!("1000000000000000000000000000000000000011");
+
+/// A SALT environment that always fails `get_bucket_capacity`, triggering the
+/// `sstore_set_storage_gas` → `None` → `FatalExternalError` path in the SSTORE wrapper.
+#[derive(Debug)]
+struct FailingSaltEnv;
+
+impl SaltEnv for FailingSaltEnv {
+    type Error = String;
+
+    fn get_bucket_capacity(&self, _bucket_id: BucketId) -> Result<u64, String> {
+        Err("injected salt error".into())
+    }
+
+    fn bucket_id_for_account(_account: Address) -> BucketId {
+        0
+    }
+
+    fn bucket_id_for_slot(_address: Address, _key: U256) -> BucketId {
+        0
+    }
+}
+
+/// SSTORE(key=0, value=1): a first-time non-zero write to an originally-zero slot,
+/// the only shape that triggers the dynamic storage-gas charge.
+fn sstore_fresh_slot_bytecode() -> Bytes {
+    BytecodeBuilder::default()
+        .push_number(1u64) // value
+        .push_number(0u64) // key (top of stack)
+        .append(SSTORE)
+        .append(STOP)
+        .build()
+}
+
+fn transact_with_failing_salt(
+    spec: MegaSpecId,
+    db: &mut MemoryDatabase,
+) -> Result<ResultAndState<MegaHaltReason>, EVMError<Infallible, MegaTransactionError>> {
+    let envs: ExternalEnvs<(FailingSaltEnv, EmptyExternalEnv)> =
+        ExternalEnvs { salt_env: FailingSaltEnv, oracle_env: EmptyExternalEnv };
+    let mut context = MegaContext::new(db, spec)
+        .with_external_envs(envs)
+        .with_tx_runtime_limits(EvmTxRuntimeLimits::no_limits());
+    context.modify_chain(|chain| {
+        chain.operator_fee_scalar = Some(U256::from(0));
+        chain.operator_fee_constant = Some(U256::from(0));
+    });
+    let mut evm = MegaEvm::new(context);
+    let tx = TxEnv {
+        caller: CALLER,
+        kind: TxKind::Call(CONTRACT),
+        data: Bytes::new(),
+        value: U256::ZERO,
+        gas_limit: 1_000_000,
+        ..Default::default()
+    };
+    let mut tx = MegaTransaction::new(tx);
+    tx.enveloped_tx = Some(Bytes::new());
+    alloy_evm::Evm::transact_raw(&mut evm, tx)
+}
+
+/// A failing SALT pricing on a first-time SSTORE write must halt the instruction with
+/// `FatalExternalError` before the inner SSTORE executes, surfacing as `EVMError::Custom`.
+#[test]
+fn test_rex5_sstore_salt_error_halts_with_fatal_external_error() {
+    let mut db = MemoryDatabase::default()
+        .account_balance(CALLER, U256::from(1_000_000_000_000u64))
+        .account_code(CONTRACT, sstore_fresh_slot_bytecode());
+
+    let result = transact_with_failing_salt(MegaSpecId::REX5, &mut db);
+
+    match result {
+        Err(EVMError::Custom(msg)) => {
+            assert!(
+                msg.contains("injected salt error"),
+                "error message should contain salt error, got: {msg}"
+            );
+        }
+        Err(other) => panic!("expected EVMError::Custom, got: {other:?}"),
+        Ok(result) => panic!("expected error, got success: {:?}", result.result),
+    }
+}

--- a/crates/mega-evm/tests/rex5/sstore_storage_gas_error.rs
+++ b/crates/mega-evm/tests/rex5/sstore_storage_gas_error.rs
@@ -1,9 +1,9 @@
 //! SSTORE storage-gas pricing error path.
 //!
-//! The dynamically-scaled storage gas for a first-time non-zero write is charged inline
-//! in `additional_limit_ext::sstore`, before the inner SSTORE executes. When the SALT
-//! environment fails to price the slot (`sstore_set_storage_gas` returns `None`), the
-//! instruction must halt with `FatalExternalError`, which surfaces as `EVMError::Custom`.
+//! The dynamically-scaled storage gas for a first-time non-zero write is charged in
+//! `storage_gas_ext::sstore`, before the inner SSTORE executes. When the SALT environment
+//! fails to price the slot (`sstore_set_storage_gas` returns `None`), the instruction must
+//! halt with `FatalExternalError`, which surfaces as `EVMError::Custom`.
 
 use std::convert::Infallible;
 


### PR DESCRIPTION
## Summary

Four behavior-preserving performance optimizations on the per-opcode hot path and pre-execution, plus benchmarks and regression tests. No semantics change for any existing spec — results are bit-identical, so no new spec is introduced.

- **Per-opcode limit check, compute-only.** `record_compute_gas` used to fan out to all four resource dimensions on every opcode, but only compute gas can change there. It now checks that single dimension; the other three are checked and latched at their own mutation sites (`on_sstore`, `on_log`, frame-lifecycle hooks, …) and surfaced by the per-opcode short-circuit, so every exceed still halts at the same opcode. The latch protocol is documented in AGENTS.md and guarded by a debug-only assertion in `record_compute_gas`.
- **Lean opcode wrapper.** `wrap_op_compute_gas!` is split into a default and a `@frame` variant; only the call/create family can set `InterpreterAction::NewFrame`, so the ~95 simple opcodes drop the always-missed child-gas-subtraction match.
- **EIP-7702 authority scan O(N²) → O(N log N).** The transaction-local seen-authorities list becomes a `BTreeMap`, removing a node-CPU amplification reachable with ~1200 unique authorities in one type-4 tx.
- **Static-frame SELFDESTRUCT early-exit.** Inside a STATICCALL frame the inner instruction always halts on revm's static check, so the wrapper skips the beneficiary/caller inspections and SALT pricing that the frame revert would discard anyway.

A fifth change (inlining the SSTORE storage-gas charge to drop a redundant warm-path `inspect_storage`) was reverted after review: it made SSTORE the only opcode charging storage gas outside `storage_gas_ext`, breaking the wrapper-layer invariant for a few in-memory map probes. The SSTORE speedups below come from the compute-only check, not the inlining.

## Measurements

CI Criterion, same-runner back-to-back (baseline `origin/main` → PR head). 267 benchmarks: 0 regressions, 1 warning (snailtracer/equivalence, runner noise on the un-instrumented mainnet path), 55 improvements.

- Hot path (rex4 vs vanilla revm): snailtracer −38%, sstore_100 −20%, sstore_sload_100 −19%, mixed_workload −17%, bytecode analysis −14%; gains span every workload category since the optimization targets the shared metering base.
- `eip7702_authlist` sweep (150/400/800/1200 authorities): per-auth cost was growing 0.35 → 0.74 µs (quadratic), now flat ~0.3 µs; −57% total at N=1200, with the improvement growing with N as expected from removing the O(N²) term.
- `staticcall_selfdestruct` (500 calls): the wasted-work gap vs the STOP-child control shrinks 26.1 µs → 8.6 µs (−67%, ~35 ns/event).

## Tests & benches

- New bench `eip7702_authlist`: sweeps authority count with pre-recovered authorizations, so a quadratic term shows as super-linear growth.
- New bench `staticcall_selfdestruct`: SELFDESTRUCT child vs STOP control, isolating the skipped host work.
- New tests: static SELFDESTRUCT leaks no tracked usage; compute gas is recorded even when another dimension already latched; SELFDESTRUCT beneficiary usage latches only at the trailing all-dimension check; SSTORE SALT-pricing failure halts with `FatalExternalError`.
- The debug-only latch-protocol assertion runs across the whole test suite, so any mutation site that forgets to latch trips at the exact opcode.
- Full suite passes (965 tests); clippy and fmt clean.