### PR TITLE
docs: sync spec and mega-evme docs to Rex5

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,7 +121,7 @@ A transaction can be halted by exceeding either limit.
 
 #### Multidimensional Resource Limits
 
-Beyond the dual gas model, mega-evm enforces **four independent per-transaction resource limits** via `AdditionalLimit` (`limit/mod.rs`):
+Beyond the dual gas model, mega-evm enforces **four independent per-transaction resource limits** via `AdditionalLimit` (`limit/limit.rs`):
 
 - **Compute gas** — Computational opcode cost
 - **Data size** — Calldata + logs + storage writes + code deploy + account updates

--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -499,9 +499,9 @@ where
                 .borrow_mut()
                 .record_compute_gas(initial_and_floor_gas.initial_gas);
 
-            // MegaETH MiniRex modification: calldata storage gas costs
-            // - Standard tokens: 400 gas per token (vs 4)
-            // - EIP-7623 floor: 100x increase for transaction data floor cost
+            // MegaETH MiniRex modification: calldata storage gas costs (10x the standard EVM rates)
+            // - Standard tokens: 40 gas per token (vs 4)
+            // - EIP-7623 floor: 100 gas per token (vs 10)
             let tokens_in_calldata = get_tokens_in_calldata(ctx.tx().input(), true);
             let calldata_storage_gas =
                 constants::mini_rex::CALLDATA_STANDARD_TOKEN_STORAGE_GAS * tokens_in_calldata;

--- a/docs/mega-evme/commands/replay.md
+++ b/docs/mega-evme/commands/replay.md
@@ -188,7 +188,7 @@ See the linked pages for full details.
   See [State Management](../configuration/state-management.md).
 - **RPC cache file** — Single-file JSON-RPC capture and offline replay via `--rpc.capture-file` / `--rpc.replay-file`.
   See [RPC Cache File](#rpc-cache-file) above.
-- **RPC cache / retry** — Per-chain response cache, chain-id override, retry and rate-limit settings.
+- **RPC cache / retry** — Per-chain response cache, retry, and rate-limit settings.
   See [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry).
 - **Tracing** — Emit execution traces (call traces, opcode traces, gas profiles, etc.).
   See [Tracing Overview](../tracing/overview.md).

--- a/docs/mega-evme/commands/run.md
+++ b/docs/mega-evme/commands/run.md
@@ -50,11 +50,11 @@ Each group is documented on its own page.
 | Group             | Flags                                                                                                                                                                                      | Reference                                                                       |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | Transaction       | `--create`, `--gas`, `--basefee`, `--priority-fee`, `--tx-type`, `--value`, `--sender`, `--receiver`, `--nonce`, `--input`, `--inputfile`, `--source-hash`, `--mint`, `--auth`, `--access` | [Transaction Types](../transaction-types.md)                                    |
-| State management  | `--prestate`, `--sender.balance`, `--dump`, `--dump.output`                                                                                                                                | [State Management](../configuration/state-management.md)                        |
+| State management  | `--prestate`, `--sender.balance`, `--faucet`, `--balance`, `--storage`, `--block-hash`, `--fork`, `--fork.block`, `--rpc`, `--dump`, `--dump.output`                                       | [State Management](../configuration/state-management.md)                        |
 | Chain and spec    | `--spec`, `--chain-id`                                                                                                                                                                     | [Chain and Spec](../configuration/chain-and-spec.md)                            |
 | Block environment | `--block.number`, `--block.coinbase`, `--block.timestamp`, `--block.gaslimit`, `--block.basefee`, `--block.difficulty`, `--block.prevrandao`, `--block.blobexcessgas`                      | [Block Environment](../configuration/block-environment.md)                      |
 | SALT buckets      | `--bucket-capacity`                                                                                                                                                                        | [SALT Buckets](../configuration/salt-buckets.md)                                |
-| RPC cache / retry | `--rpc.cache-size`, `--rpc.cache-dir`, `--rpc.no-cache-file`, `--rpc.chain-id`, `--rpc.clear-cache`, `--rpc.max-retries`, `--rpc.backoff-ms`, `--rpc.rate-limit`                           | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
+| RPC cache / retry | `--rpc.cache-size`, `--rpc.cache-dir`, `--rpc.no-cache-file`, `--rpc.clear-cache`, `--rpc.max-retries`, `--rpc.backoff-ms`, `--rpc.rate-limit`                                             | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
 | Tracing           | `--trace`, `--tracer`, `--trace.output`, and tracer-specific flags                                                                                                                         | [Tracing Overview](../tracing/overview.md)                                      |
 | Output            | `--json`                                                                                                                                                                                   | See [JSON output](#json-output) below                                           |
 
@@ -62,7 +62,7 @@ Each group is documented on its own page.
 
 | Option       | Default                                      |
 | ------------ | -------------------------------------------- |
-| `--spec`     | `Rex4`                                       |
+| `--spec`     | `Rex5`                                       |
 | `--gas`      | `10000000`                                   |
 | `--sender`   | `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` |
 | `--receiver` | `0x0000000000000000000000000000000000000000` |
@@ -266,11 +266,6 @@ State Options:
       --fork.block <FORK_BLOCK>
           Block number of the state (post-block state) to fork from
 
-      --rpc <RPC_URL>
-          RPC URL [env: RPC_URL=] [default: http://localhost:8545]
-
-          [aliases: --rpc-url] [compat alias: --fork.rpc]
-
       --prestate <PRESTATE>
           JSON file with prestate (genesis) config
 
@@ -295,9 +290,42 @@ State Options:
       --storage <STORAGE>
           Override storage slots. Format: `ADDRESS:SLOT=VALUE` (repeatable)
 
+RPC Options:
+      --rpc <RPC_URL>
+          RPC URL. Required for networked operation (replay, run --fork, tx --fork). No default; the RPC_URL environment variable is not consulted
+
+          [aliases: --rpc-url] [compat alias: --fork.rpc]
+
+      --rpc.capture-file <CAPTURE_FILE>
+          Capture JSON-RPC responses to a file for later offline replay. Requires --rpc
+
+      --rpc.replay-file <REPLAY_FILE>
+          Replay from a previously captured JSON-RPC fixture file (offline). Cannot be used with --rpc
+
+      --rpc.cache-size <cache_size>
+          Max items in the in-memory RPC LRU cache; 0 disables it [default: 10000]
+
+      --rpc.cache-dir <CACHE_DIR>
+          Directory for per-chain RPC cache files (default: platform cache dir)
+
+      --rpc.no-cache-file
+          Disable on-disk cache persistence (the in-memory LRU still applies)
+
+      --rpc.clear-cache
+          Delete the current chain's cache file before loading it
+
+      --rpc.max-retries <MAX_RETRIES>
+          Max transport retries on 429/503, rate-limit, and transport failures; 0 disables [default: 5]
+
+      --rpc.backoff-ms <BACKOFF_MS>
+          Fixed sleep (ms) between retries; no exponential backoff [default: 1000]
+
+      --rpc.rate-limit <COMPUTE_UNITS_PER_SEC>
+          Compute-units-per-second budget for the retry layer [default: 660]
+
 Chain Options:
       --spec <SPEC>
-          Spec to use: MiniRex, Equivalence, Rex, Rex1, Rex2, Rex3, Rex4 [default: Rex4]
+          Spec to use: MiniRex, Equivalence, Rex, Rex1, Rex2, Rex3, Rex4, Rex5 [default: Rex5]
 
       --chain-id <CHAIN_ID>
           Chain ID [default: 6342] [aliases: --chainid]

--- a/docs/mega-evme/commands/run.md
+++ b/docs/mega-evme/commands/run.md
@@ -291,7 +291,7 @@ State Options:
           Override storage slots. Format: `ADDRESS:SLOT=VALUE` (repeatable)
 
 RPC Options:
-      (On run/tx, --rpc and the --rpc.* options below take effect only with --fork; without --fork they are accepted but ignored.)
+      (On run/tx, --rpc and the --rpc.* cache/retry options below take effect only with --fork; without --fork they are accepted but ignored. The capture/replay fixture flags are replay-command-only.)
 
       --rpc <RPC_URL>
           RPC URL. Required for networked operation (replay, run --fork, tx --fork). No default; the RPC_URL environment variable is not consulted

--- a/docs/mega-evme/commands/run.md
+++ b/docs/mega-evme/commands/run.md
@@ -291,16 +291,18 @@ State Options:
           Override storage slots. Format: `ADDRESS:SLOT=VALUE` (repeatable)
 
 RPC Options:
+      (On run/tx, --rpc and the --rpc.* options below take effect only with --fork; without --fork they are accepted but ignored.)
+
       --rpc <RPC_URL>
           RPC URL. Required for networked operation (replay, run --fork, tx --fork). No default; the RPC_URL environment variable is not consulted
 
           [aliases: --rpc-url] [compat alias: --fork.rpc]
 
       --rpc.capture-file <CAPTURE_FILE>
-          Capture JSON-RPC responses to a file for later offline replay. Requires --rpc
+          (replay command only) Capture JSON-RPC responses to a fixture file; not usable as a run/tx offline-fork path
 
       --rpc.replay-file <REPLAY_FILE>
-          Replay from a previously captured JSON-RPC fixture file (offline). Cannot be used with --rpc
+          (replay command only) Serve JSON-RPC from a captured fixture; not usable as a run/tx offline-fork path
 
       --rpc.cache-size <cache_size>
           Max items in the in-memory RPC LRU cache; 0 disables it [default: 10000]

--- a/docs/mega-evme/commands/tx.md
+++ b/docs/mega-evme/commands/tx.md
@@ -199,7 +199,7 @@ State Options:
       --storage <STORAGE>                Set storage: ADDRESS:SLOT=VALUE (repeatable)
 
 RPC Options:
-      (On run/tx, --rpc and --rpc.* take effect only with --fork; otherwise accepted but ignored.)
+      (On run/tx, --rpc and the --rpc.* cache/retry options take effect only with --fork; otherwise accepted but ignored. Capture/replay fixture flags are replay-command-only.)
       --rpc <RPC_URL>                    RPC URL (required for --fork; no default, RPC_URL env not used)
                                          [aliases: --rpc-url] [compat alias: --fork.rpc]
       --rpc.capture-file <PATH>          (replay command only) capture to fixture; not usable as a run/tx offline path

--- a/docs/mega-evme/commands/tx.md
+++ b/docs/mega-evme/commands/tx.md
@@ -70,7 +70,7 @@ Each group has its own reference page with the full flag table.
 | Chain / spec      | Spec version, chain ID                                               | [Chain and Spec](../configuration/chain-and-spec.md)                            |
 | Block environment | Block number, timestamp, coinbase, basefee, gas limit, prevrandao    | [Block Environment](../configuration/block-environment.md)                      |
 | SALT buckets      | Per-bucket capacity overrides for dynamic gas pricing                | [SALT Buckets](../configuration/salt-buckets.md)                                |
-| RPC cache / retry | Cache size, cache dir, capture/replay file, retry and rate-limit     | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
+| RPC cache / retry | Cache size, cache dir, retry and rate-limit                          | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
 | Tracing           | Opcode, call, and pre-state tracers with output options              | [Tracing Overview](../tracing/overview.md)                                      |
 | Output            | JSON output mode                                                     | See [JSON output](#json-output) below                                           |
 
@@ -199,10 +199,11 @@ State Options:
       --storage <STORAGE>                Set storage: ADDRESS:SLOT=VALUE (repeatable)
 
 RPC Options:
+      (On run/tx, --rpc and --rpc.* take effect only with --fork; otherwise accepted but ignored.)
       --rpc <RPC_URL>                    RPC URL (required for --fork; no default, RPC_URL env not used)
                                          [aliases: --rpc-url] [compat alias: --fork.rpc]
-      --rpc.capture-file <PATH>          Capture JSON-RPC responses for offline replay (requires --rpc)
-      --rpc.replay-file <PATH>           Replay from a captured fixture file (offline; cannot use --rpc)
+      --rpc.capture-file <PATH>          (replay command only) capture to fixture; not usable as a run/tx offline path
+      --rpc.replay-file <PATH>           (replay command only) serve from fixture; not usable as a run/tx offline path
       --rpc.cache-size <N>               In-memory RPC LRU cache size; 0 disables [default: 10000]
       --rpc.cache-dir <DIR>              Per-chain RPC cache directory (default: platform cache dir)
       --rpc.no-cache-file                Disable on-disk cache persistence

--- a/docs/mega-evme/commands/tx.md
+++ b/docs/mega-evme/commands/tx.md
@@ -39,21 +39,20 @@ The default sender is `0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266` and the defau
 By default, `tx` runs against local state — either empty or loaded from a `--prestate` file.
 Fork mode fetches account balances, contract code, and storage slots on demand from a remote RPC node, so you can call real deployed contracts without manually constructing their state.
 
-| Flag                    | Default                 | Description                                |
-| ----------------------- | ----------------------- | ------------------------------------------ |
-| `--fork`                | `false`                 | Enable state forking from RPC              |
-| `--rpc <URL>`           | `http://localhost:8545` | RPC endpoint to fork from (env: `RPC_URL`) |
-| `--fork.block <NUMBER>` | latest                  | Pin the fork to a specific block number    |
+| Flag                    | Default  | Description                                                    |
+| ----------------------- | -------- | -------------------------------------------------------------- |
+| `--fork`                | `false`  | Enable state forking from RPC                                  |
+| `--rpc <URL>`           | required | RPC endpoint to fork from (aliases: `--rpc-url`, `--fork.rpc`) |
+| `--fork.block <NUMBER>` | latest   | Pin the fork to a specific block number                        |
 
 When `--fork` is set, `mega-evme` connects to `--rpc` and resolves any state reads that aren't covered by a local `--prestate` file against that node.
 `--fork.block` pins the fork to a specific block's post-state, which is useful for reproducing historical behavior or writing deterministic tests.
 Without `--fork.block`, the fork uses the latest block at the time of execution.
 
-You can set the RPC URL via the `RPC_URL` environment variable instead of passing `--rpc` every time:
+`--fork` requires `--rpc` — there is no default endpoint, and the `RPC_URL` environment variable is not consulted:
 
 ```bash
-export RPC_URL=https://mainnet.megaeth.com/rpc
-mega-evme tx --fork --sender.balance 1ether --receiver 0x4200000000000000000000000000000000000006 --input 0x06fdde03
+mega-evme tx --fork --rpc https://mainnet.megaeth.com/rpc --sender.balance 1ether --receiver 0x4200000000000000000000000000000000000006 --input 0x06fdde03
 ```
 
 Local `--prestate` overrides take precedence over forked state.
@@ -71,7 +70,7 @@ Each group has its own reference page with the full flag table.
 | Chain / spec      | Spec version, chain ID                                               | [Chain and Spec](../configuration/chain-and-spec.md)                            |
 | Block environment | Block number, timestamp, coinbase, basefee, gas limit, prevrandao    | [Block Environment](../configuration/block-environment.md)                      |
 | SALT buckets      | Per-bucket capacity overrides for dynamic gas pricing                | [SALT Buckets](../configuration/salt-buckets.md)                                |
-| RPC cache / retry | Cache size, cache dir, chain-id override, retry and rate-limit       | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
+| RPC cache / retry | Cache size, cache dir, capture/replay file, retry and rate-limit     | [RPC Cache and Retry](../configuration/state-management.md#rpc-cache-and-retry) |
 | Tracing           | Opcode, call, and pre-state tracers with output options              | [Tracing Overview](../tracing/overview.md)                                      |
 | Output            | JSON output mode                                                     | See [JSON output](#json-output) below                                           |
 
@@ -192,8 +191,6 @@ Transaction Options:
 State Options:
       --fork                             Fork state from remote RPC
       --fork.block <FORK_BLOCK>          Block to fork from (default: latest)
-      --rpc <RPC_URL>                    RPC URL [env: RPC_URL=] [default: http://localhost:8545]
-                                         [aliases: --rpc-url] [compat alias: --fork.rpc]
       --prestate <PRESTATE>              JSON prestate file [aliases: --pre-state]
       --block-hash <BLOCK_HASHES>        BLOCKHASH overrides (repeatable) [aliases: --blockhash]
       --sender.balance <SENDER_BALANCE>  Sender balance (supports suffixes) [aliases: --from.balance]
@@ -201,8 +198,21 @@ State Options:
       --balance <BALANCE>                Set balance: ADDRESS=VALUE (repeatable)
       --storage <STORAGE>                Set storage: ADDRESS:SLOT=VALUE (repeatable)
 
+RPC Options:
+      --rpc <RPC_URL>                    RPC URL (required for --fork; no default, RPC_URL env not used)
+                                         [aliases: --rpc-url] [compat alias: --fork.rpc]
+      --rpc.capture-file <PATH>          Capture JSON-RPC responses for offline replay (requires --rpc)
+      --rpc.replay-file <PATH>           Replay from a captured fixture file (offline; cannot use --rpc)
+      --rpc.cache-size <N>               In-memory RPC LRU cache size; 0 disables [default: 10000]
+      --rpc.cache-dir <DIR>              Per-chain RPC cache directory (default: platform cache dir)
+      --rpc.no-cache-file                Disable on-disk cache persistence
+      --rpc.clear-cache                  Delete the current chain's cache file before loading
+      --rpc.max-retries <N>              Max transport retries; 0 disables [default: 5]
+      --rpc.backoff-ms <MS>              Fixed retry sleep in ms [default: 1000]
+      --rpc.rate-limit <CU/S>            Retry-layer compute-units-per-second budget [default: 660]
+
 Chain Options:
-      --spec <SPEC>                Spec [default: Rex4]
+      --spec <SPEC>                Spec [default: Rex5]
       --chain-id <CHAIN_ID>       Chain ID [default: 6342] [aliases: --chainid]
 
 Block Options:

--- a/docs/mega-evme/configuration/chain-and-spec.md
+++ b/docs/mega-evme/configuration/chain-and-spec.md
@@ -12,22 +12,23 @@ The `replay` command auto-detects the spec from the chain ID and block timestamp
 
 | Flag              | Default | Aliases     | Description         |
 | ----------------- | ------- | ----------- | ------------------- |
-| `--spec <SPEC>`   | `Rex4`  | —           | MegaETH spec to use |
+| `--spec <SPEC>`   | `Rex5`  | —           | MegaETH spec to use |
 | `--chain-id <ID>` | `6342`  | `--chainid` | Chain ID            |
 
 ## Available Specs
 
 Spec names are case-sensitive.
 
-| Name          | Description                                                                  |
-| ------------- | ---------------------------------------------------------------------------- |
-| `Equivalence` | Optimism Isthmus compatibility mode                                          |
-| `MiniRex`     | Initial MegaETH execution model with multidimensional gas                    |
-| `Rex`         | Revised storage gas economics and gas forwarding                             |
-| `Rex1`        | Compute gas limit reset fix                                                  |
-| `Rex2`        | SELFDESTRUCT restored (EIP-6780), KeylessDeploy system contract              |
-| `Rex3`        | SLOAD-based oracle detention, increased oracle gas limit                     |
-| `Rex4`        | Per-call-frame resource budgets, relative gas detention, storage gas stipend |
+| Name          | Description                                                                                                                   |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `Equivalence` | Optimism Isthmus compatibility mode                                                                                           |
+| `MiniRex`     | Initial MegaETH execution model with multidimensional gas                                                                     |
+| `Rex`         | Revised storage gas economics and gas forwarding                                                                              |
+| `Rex1`        | Compute gas limit reset fix                                                                                                   |
+| `Rex2`        | SELFDESTRUCT restored (EIP-6780), KeylessDeploy system contract                                                               |
+| `Rex3`        | SLOAD-based oracle detention, increased oracle gas limit                                                                      |
+| `Rex4`        | Per-call-frame resource budgets, relative gas detention, storage gas stipend                                                  |
+| `Rex5`        | SequencerRegistry, dynamic system address (Oracle v2.0.0), storage-gas-stipend separated allowance, resource-accounting fixes |
 
 ## Examples
 

--- a/docs/mega-evme/configuration/state-management.md
+++ b/docs/mega-evme/configuration/state-management.md
@@ -117,14 +117,14 @@ This is useful when testing contracts that branch on historical block hashes.
 ## Fork Mode
 
 Fork mode fetches account state from a live RPC endpoint instead of starting from an empty state.
-Enable it with `--fork`:
+Enable it with `--fork`, which requires `--rpc`:
 
 ```bash
-mega-evme run --fork ...
+mega-evme run --fork --rpc https://mainnet.megaeth.com/rpc ...
 ```
 
-By default it connects to `http://localhost:8545`.
-Override the endpoint with `--rpc` (or the `RPC_URL` environment variable) and pin a specific block with `--fork.block`:
+There is no default endpoint, and the `RPC_URL` environment variable is not consulted — `--rpc` must be passed explicitly.
+Set the endpoint with `--rpc` (aliases `--rpc-url`, `--fork.rpc`) and pin a specific block with `--fork.block`:
 
 ```bash
 mega-evme run \
@@ -222,7 +222,6 @@ The default cache directory is the platform cache directory:
 | `--rpc.cache-size <N>`   | `u32` | `10000`            | Maximum number of items in the in-memory RPC LRU cache. Set to `0` to disable the cache layer entirely.                  |
 | `--rpc.cache-dir <PATH>` | path  | Platform cache dir | Directory for per-chain cache files. Each chain's cache is stored as `{cache_dir}/rpc-cache-{chain_id}.json`.            |
 | `--rpc.no-cache-file`    | flag  | `false`            | Disable on-disk cache persistence. The in-memory LRU cache still applies — use `--rpc.cache-size 0` to disable that too. |
-| `--rpc.chain-id <ID>`    | `u64` | auto-detected      | Chain ID override. Skips the `eth_chainId` RPC call at startup and uses this value to locate the per-chain cache file.   |
 | `--rpc.clear-cache`      | flag  | `false`            | Delete the current chain's cache file before loading it. Recovery path for a polluted or corrupt cache.                  |
 
 ### Retry Flags
@@ -235,25 +234,28 @@ The default cache directory is the platform cache directory:
 
 ### Examples
 
-Replay a transaction with a local cache directory and explicit chain ID (fully offline if the cache is warm):
+Replay a transaction with a local per-chain cache directory (a warm cache avoids redundant RPC calls on later runs):
 
 ```bash
 mega-evme replay \
-  --rpc.chain-id 4326 \
+  --rpc https://mainnet.megaeth.com/rpc \
   --rpc.cache-dir ./my-cache \
   0xabc123...
 ```
 
+The per-chain cache supplements `--rpc`; it does not replace it.
+For a fully offline replay, capture a single-file fixture and replay it with `--rpc.replay-file` (see [replay](../commands/replay.md#rpc-cache-file)).
+
 Disable on-disk caching but keep the in-memory LRU:
 
 ```bash
-mega-evme tx --fork --rpc.no-cache-file ...
+mega-evme tx --fork --rpc https://mainnet.megaeth.com/rpc --rpc.no-cache-file ...
 ```
 
 Clear a corrupt cache before replaying:
 
 ```bash
-mega-evme replay --rpc.clear-cache 0xabc123...
+mega-evme replay --rpc https://mainnet.megaeth.com/rpc --rpc.clear-cache 0xabc123...
 ```
 
 ## Round-Trip Example

--- a/docs/mega-evme/configuration/state-management.md
+++ b/docs/mega-evme/configuration/state-management.md
@@ -205,7 +205,7 @@ All numeric values use Ethereum quantity encoding:
 
 When using fork mode, `mega-evme` caches RPC responses to avoid redundant network calls and supports configurable retry behavior for resilience against transient failures.
 
-These options take effect only when an RPC endpoint is actually used: on `run` and `tx` that means together with `--fork` — without `--fork` they are accepted but silently ignored — while the `replay` command always uses them.
+These options take effect only when an RPC endpoint is actually contacted: on `run` and `tx` that requires `--fork` (without `--fork` they are accepted but silently ignored); on `replay` they apply to its `--rpc` fetches (an offline `--rpc.replay-file` run contacts no endpoint and does not use them).
 
 ### Per-Chain Cache Files
 

--- a/docs/mega-evme/configuration/state-management.md
+++ b/docs/mega-evme/configuration/state-management.md
@@ -205,6 +205,8 @@ All numeric values use Ethereum quantity encoding:
 
 When using fork mode, `mega-evme` caches RPC responses to avoid redundant network calls and supports configurable retry behavior for resilience against transient failures.
 
+These options take effect only when an RPC endpoint is actually used: on `run` and `tx` that means together with `--fork` — without `--fork` they are accepted but silently ignored — while the `replay` command always uses them.
+
 ### Per-Chain Cache Files
 
 Each chain gets its own cache file named `rpc-cache-{chain_id}.json` inside the cache directory.

--- a/docs/mega-evme/transaction-types.md
+++ b/docs/mega-evme/transaction-types.md
@@ -32,11 +32,14 @@ Uses a single gas price (`--basefee`) for all gas costs.
 
 ```bash
 mega-evme tx --tx-type 0 \
+  --sender.balance 1ether \
   --receiver 0x4200000000000000000000000000000000000006 \
   --gas 100000 \
   --basefee 1000000000 \
   --input 0x06fdde03
 ```
+
+A transaction with a non-zero `--basefee` requires the sender to hold enough balance to cover `gas × basefee`; fund it with `--sender.balance` (or run against forked/prestate state).
 
 ## Type 1 — EIP-2930 (Access List)
 
@@ -54,11 +57,13 @@ Access list entry format:
 - `ADDRESS` — pre-warm an address (no storage keys)
 - `ADDRESS:KEY1,KEY2,...` — pre-warm an address and specific storage keys (comma-separated)
 
+Storage keys are full 32-byte hex values (64 hex digits, `0x`-prefixed); abbreviated forms like `0x0` are rejected.
+
 ```bash
 mega-evme tx --tx-type 1 \
   --receiver 0x4200000000000000000000000000000000000006 \
   --access "0x4200000000000000000000000000000000000006" \
-  --access "0x28B7E77f82B25B95953825F1E3eA0E36c1c29861:0x0,0x1" \
+  --access "0x28B7E77f82B25B95953825F1E3eA0E36c1c29861:0x0000000000000000000000000000000000000000000000000000000000000000,0x0000000000000000000000000000000000000000000000000000000000000001" \
   --input 0x06fdde03
 ```
 
@@ -69,10 +74,11 @@ Also supports access lists.
 
 ```bash
 mega-evme tx --tx-type 2 \
+  --sender.balance 1ether \
   --receiver 0x4200000000000000000000000000000000000006 \
   --basefee 30000000000 \
   --priority-fee 1000000000 \
-  --access "0x4200000000000000000000000000000000000006:0x0" \
+  --access "0x4200000000000000000000000000000000000006:0x0000000000000000000000000000000000000000000000000000000000000000" \
   --input 0x06fdde03
 ```
 

--- a/docs/spec/evm/gas-detention.md
+++ b/docs/spec/evm/gas-detention.md
@@ -145,6 +145,8 @@ The detained compute gas limit MUST remain in effect for the rest of the transac
 | `ORACLE_DETENTION_CAP`         | 20,000,000 | Relative compute gas cap after oracle storage access                 |
 | `ORACLE_DETENTION_CAP_MINIREX` | 1,000,000  | Historical absolute compute gas cap after oracle access (superseded) |
 
+`BLOCK_ENV_DETENTION_CAP` and `BENEFICIARY_DETENTION_CAP` have the same value: block-environment and beneficiary access are detained at the same level.
+
 ## Rationale
 
 **Why detention instead of outright prohibition?**

--- a/docs/spec/evm/gas-forwarding.md
+++ b/docs/spec/evm/gas-forwarding.md
@@ -51,11 +51,6 @@ The child call frame gas for value-transferring `CALL` and `CALLCODE` MUST be:
 
 For `DELEGATECALL`, `STATICCALL`, `CREATE`, and `CREATE2`, no call stipend applies.
 
-### Opcode Scope by Spec Version
-
-For [MiniRex](../upgrades/minirex.md), the 98/100 rule applied only to `CALL`, `CREATE`, and `CREATE2`.
-For [Rex](../upgrades/rex.md) and later stable specs, the 98/100 rule applies to all CALL-like opcodes and both contract-creation opcodes.
-
 ### [Storage Gas Stipend](../glossary.md#storage-gas-stipend) Interaction
 
 For internal (call depth greater than zero) value-transferring `CALL` and `CALLCODE`, the callee frame receives a `STORAGE_CALL_STIPEND` allowance.

--- a/docs/spec/evm/selfdestruct.md
+++ b/docs/spec/evm/selfdestruct.md
@@ -58,18 +58,12 @@ This refund MUST NOT be applied when `SELFDESTRUCT` targets a pre-existing accou
 
 The refund is frame-aware: if the call frame that performed the `SELFDESTRUCT` reverts, the refund MUST be discarded together with the destruction effect.
 
-### MiniRex Behavior
-
-For [MiniRex](../upgrades/minirex.md), [Rex](../upgrades/rex.md), and [Rex1](../upgrades/rex1.md), `SELFDESTRUCT` MUST be disabled.
-When disabled, executing `SELFDESTRUCT` MUST halt with `InvalidFEOpcode`.
-
 ## Constants
 
-| Constant                              | Value             | Description                                                                        |
-| ------------------------------------- | ----------------- | ---------------------------------------------------------------------------------- |
-| `SELFDESTRUCT_DISABLED_HALT`          | `InvalidFEOpcode` | Halt reason when `SELFDESTRUCT` is disabled in MiniRex through Rex1                |
-| `ACCOUNT_CREATION_STORAGE_GAS_BASE`   | 25,000            | Base storage gas charged when a value transfer creates a previously empty account  |
-| `SELFDESTRUCT_BENEFICIARY_DATA_BYTES` | 40                | Data-size bytes recorded for the beneficiary account write on beneficiary creation |
+| Constant                              | Value  | Description                                                                        |
+| ------------------------------------- | ------ | ---------------------------------------------------------------------------------- |
+| `ACCOUNT_CREATION_STORAGE_GAS_BASE`   | 25,000 | Base storage gas charged when a value transfer creates a previously empty account  |
+| `SELFDESTRUCT_BENEFICIARY_DATA_BYTES` | 40     | Data-size bytes recorded for the beneficiary account write on beneficiary creation |
 
 ## Rationale
 
@@ -92,7 +86,7 @@ Charging the same account-creation storage gas and recording the same resource-l
 
 ## Spec History
 
-- [MiniRex](../upgrades/minirex.md), [Rex](../upgrades/rex.md), and [Rex1](../upgrades/rex1.md) disable `SELFDESTRUCT`.
+- [MiniRex](../upgrades/minirex.md), [Rex](../upgrades/rex.md), and [Rex1](../upgrades/rex1.md) disable `SELFDESTRUCT`; executing it halts with `InvalidFEOpcode`.
 - [Rex2](../upgrades/rex2.md) re-enables `SELFDESTRUCT` with [EIP-6780](https://eips.ethereum.org/EIPS/eip-6780) semantics.
 - [Rex4](../upgrades/rex4.md) — added beneficiary-triggered volatile-access behavior for SELFDESTRUCT, and [state growth refund](#state-growth-refund) for same-transaction-created accounts destroyed by `SELFDESTRUCT`.
 - [Rex5](../upgrades/rex5.md) — charged account-creation storage gas and recorded data-size, KV-update, and state-growth usage when a value-carrying `SELFDESTRUCT` creates a previously non-existent beneficiary account.

--- a/docs/spec/evm/selfdestruct.md
+++ b/docs/spec/evm/selfdestruct.md
@@ -1,5 +1,5 @@
 ---
-description: SELFDESTRUCT opcode on MegaETH — EIP-6780 semantics, same-transaction destruction, and spec history from MiniRex to Rex2.
+description: SELFDESTRUCT opcode on MegaETH — EIP-6780 semantics, same-transaction destruction, beneficiary account metering, and spec history from MiniRex to Rex5.
 spec: Rex5
 ---
 

--- a/docs/spec/system-contracts/high-precision-timestamp.md
+++ b/docs/spec/system-contracts/high-precision-timestamp.md
@@ -24,23 +24,25 @@ The High-Precision Timestamp contract MUST exist at `HIGH_PRECISION_TIMESTAMP_AD
 
 ### Interface
 
-The contract MUST expose the following interface:
+The contract MUST expose the following methods:
 
 ```solidity
 interface IHighPrecisionTimestamp {
     function timestamp() external view returns (uint256);
-    function update(uint256 index) external;
-    function oracle() external view returns (address);
-    function baseSlot() external view returns (uint256);
-    function maxSlots() external view returns (uint32);
+    function update(uint256 ts) external;
+    function ORACLE_CONTRACT_ADDRESS() external view returns (address);
+    function ALLOCATION_START() external view returns (uint256);
+    function ALLOCATION_SIZE() external view returns (uint32);
 }
 ```
 
-`oracle()` MUST return `ORACLE_CONTRACT_ADDRESS`.
-`baseSlot()` MUST return `TIMESTAMP_BASE_SLOT`.
-`maxSlots()` MUST return `TIMESTAMP_MAX_SLOTS`.
-
 The `timestamp()` method MUST return the value stored at Oracle slot `TIMESTAMP_BASE_SLOT`, interpreted as a `uint256` number of microseconds since Unix epoch.
+
+The `update(uint256 ts)` method forwards a timestamp write to the [Oracle](oracle.md) contract; the write is gated by the Oracle's own [system-address](system-tx.md) authorization, so it is not callable by an ordinary on-chain sender.
+
+`ORACLE_CONTRACT_ADDRESS()` MUST return `ORACLE_CONTRACT_ADDRESS`.
+`ALLOCATION_START()` MUST return `TIMESTAMP_BASE_SLOT`.
+`ALLOCATION_SIZE()` MUST return `TIMESTAMP_MAX_SLOTS`.
 
 ### Storage Layout
 

--- a/docs/spec/system-contracts/high-precision-timestamp.md
+++ b/docs/spec/system-contracts/high-precision-timestamp.md
@@ -38,7 +38,9 @@ interface IHighPrecisionTimestamp {
 
 The `timestamp()` method MUST return the value stored at Oracle slot `TIMESTAMP_BASE_SLOT`, interpreted as a `uint256` number of microseconds since Unix epoch.
 
-The `update(uint256 ts)` method forwards a timestamp write to the [Oracle](oracle.md) contract; the write is gated by the Oracle's own [system-address](system-tx.md) authorization, so it is not callable by an ordinary on-chain sender.
+The `update(uint256 ts)` method is not an on-chain write path.
+It forwards to the [Oracle](oracle.md) `setSlot`, which authorizes the immediate caller against the current [system address](system-tx.md); because the immediate caller is the timestamp contract itself rather than the system address, an on-chain `update` call reverts.
+The current timestamp value is instead maintained by the sequencer writing the per-transaction snapshot directly to Oracle storage (see [Service Semantics](#service-semantics)).
 
 `ORACLE_CONTRACT_ADDRESS()` MUST return `ORACLE_CONTRACT_ADDRESS`.
 `ALLOCATION_START()` MUST return `TIMESTAMP_BASE_SLOT`.

--- a/docs/spec/system-contracts/high-precision-timestamp.md
+++ b/docs/spec/system-contracts/high-precision-timestamp.md
@@ -38,9 +38,9 @@ interface IHighPrecisionTimestamp {
 
 The `timestamp()` method MUST return the value stored at Oracle slot `TIMESTAMP_BASE_SLOT`, interpreted as a `uint256` number of microseconds since Unix epoch.
 
-The `update(uint256 ts)` method is not an on-chain write path.
-It forwards to the [Oracle](oracle.md) `setSlot`, which authorizes the immediate caller against the current [system address](system-tx.md); because the immediate caller is the timestamp contract itself rather than the system address, an on-chain `update` call reverts.
-The current timestamp value is instead maintained by the sequencer writing the per-transaction snapshot directly to Oracle storage (see [Service Semantics](#service-semantics)).
+The `update(uint256 ts)` method is not a usable on-chain write path under the canonical configuration.
+It forwards to the [Oracle](oracle.md) `setSlot`, which authorizes the _immediate_ caller against the current [system address](system-tx.md); because the immediate caller is the timestamp contract itself, an on-chain `update` commits only if the system address has been set to `HIGH_PRECISION_TIMESTAMP_ADDRESS`, and otherwise reverts.
+Under the canonical configuration the system address is the sequencer, not the timestamp contract, so `update` reverts and the current timestamp value is instead maintained by the sequencer writing the per-transaction snapshot directly to Oracle storage (see [Service Semantics](#service-semantics)).
 
 `ORACLE_CONTRACT_ADDRESS()` MUST return `ORACLE_CONTRACT_ADDRESS`.
 `ALLOCATION_START()` MUST return `TIMESTAMP_BASE_SLOT`.


### PR DESCRIPTION
## Summary

Brings the `docs/` set in line with the current code at the Rex5 spec, covering both the MegaETH protocol spec and the `mega-evme` CLI reference, and fixes a stale code comment found along the way.
Every numeric value, behavioral rule, interface, and CLI flag was verified against source across `mega-evm`, `mega-reth`, and `salt`; all `mega-evme` example commands were run locally against a release build; and the `docs/**/*.md` tree passes `prettier --check`.
This addresses the documentation audit in #314 (C-001–C-004, R-001, R-002) and several additional discrepancies surfaced during verification.

## mega-evme CLI reference

- Correct the `--spec` default from `Rex4` to `Rex5` and add the `Rex5` row to the spec / available-specs tables (chain-and-spec, run, tx). (#314 C-001, C-002)
- Remove the documented `--rpc.chain-id` flag, which does not exist in the CLI (confirmed at runtime: "unexpected argument").
- Correct the `--rpc` documentation: it has no default endpoint and the `RPC_URL` environment variable is not consulted; `--fork` and `replay` require an `--rpc*` source. Fix the affected examples in state-management/tx/run accordingly.
- Regenerate the stale "Full Help Output" blocks in run.md and tx.md so the option groups match the real `--help`, including a dedicated RPC Options group listing the actual `--rpc.*` cache/retry flags.
- Fix the transaction-types examples: fund the fee-bearing type-0/type-2 transactions (otherwise `LackOfFundForMaxFee`) and use full 32-byte access-list storage keys (abbreviated `0x0` keys are rejected), with a note documenting both requirements.

## Spec

- Move historical pre-latest behavior out of the gas-forwarding and selfdestruct Specification sections into Spec History, per the spec-versioning convention. (#314 R-001, R-002)
- Note that the block-environment and beneficiary gas-detention caps share a single underlying value. (#314 C-004)
- Correct the High-Precision Timestamp interface to the contract's actual method names (`timestamp`, `update(uint256 ts)`, `ORACLE_CONTRACT_ADDRESS`, `ALLOCATION_START`, `ALLOCATION_SIZE`); the previously documented `oracle()`/`baseSlot()`/`maxSlots()` getters do not exist in the deployed bytecode (their selectors revert). Names sourced from the `OracleService` base in `mega-reth`.

## Other

- AGENTS.md: fix the `AdditionalLimit` source path (`limit/mod.rs` → `limit/limit.rs`). (#314 C-003)
- chore(evm): correct a stale comment in `execution.rs` (MegaETH calldata storage gas is a 10x rate: 40 gas/token, not "400"; floor 100 gas/token).

## Verification

- Built `mega-evme` (release) and ran ~35 documented example commands; all succeed (or fail only for the expected reasons the docs now state).
- PoC-verified the timestamp contract by executing its deployed bytecode against each selector.
- Cross-checked every constant against `mega-evm/src/constants.rs`, `mega-reth` (timestamp invariants), and the `salt` repo (`NUM_META_BUCKETS`, `NUM_KV_BUCKETS`, `MIN_BUCKET_SIZE`, bucket-id formula).
- `prettier --check 'docs/**/*.md'` passes.
