### PR TITLE
tool: bump path-dep versions in lockstep in bump-version-release skill

### DIFF
--- a/.claude/skills/bump-version-release/SKILL.md
+++ b/.claude/skills/bump-version-release/SKILL.md
@@ -98,8 +98,20 @@ Use `git config user.name` to determine the username (lowercase first name).
 
 ### 2b. Update Cargo.toml
 
-Edit the `version` field under `[workspace.package]` in the root `Cargo.toml`.
-Only change the version line — do not modify anything else.
+Two places in the root `Cargo.toml` carry the workspace version, and both must move together — bumping only the first desyncs the published crates.
+
+1. The `version` field under `[workspace.package]`.
+2. The `version` requirement of every in-repo path dependency under `[workspace.dependencies]` — currently `mega-evm`, `mega-state-test`, and `mega-system-contracts` (each written as `{ path = "...", version = "X.Y.Z", ... }`).
+
+These crates are published to crates.io.
+When publishing, Cargo resolves a path dependency by its `version` requirement rather than the path, so a stale requirement lets a published `{new_version}` crate resolve against an older sibling instead of the coordinated set.
+Bump the package version and these path-dependency requirements in lockstep, and do not modify anything else.
+
+Before committing, confirm no stale version string remains:
+
+```bash
+grep -n '{old_version}' Cargo.toml   # should print nothing
+```
 
 ### 2c. Update Cargo.lock
 


### PR DESCRIPTION
## Summary

- Fix the `bump-version-release` skill so a version bump updates the workspace version in both required places, not just one.
- Step 2b previously said "only change the version line — do not modify anything else", which left the internal path-dependency `version` requirements under `[workspace.dependencies]` (`mega-evm`, `mega-state-test`, `mega-system-contracts`) stale.
- Because these crates are published to crates.io, Cargo resolves a path dependency by its `version` requirement (not the path) when publishing, so a stale requirement lets a published new-version crate resolve against an older sibling instead of the coordinated set.
- Step 2b now requires bumping `[workspace.package].version` and the path-dependency requirements in lockstep, and adds a pre-commit `grep -n '<old_version>' Cargo.toml` check that should print nothing.

## Context

- The v1.6.1 release (#317) hit exactly this: only `[workspace.package].version` was bumped, and the Codex PR reviewer flagged the desync (P2). It was confirmed real and fixed in that PR before merge.
- The v1.6.0 bump (`be4418d`) had correctly moved these same lines `1.5.1 → 1.6.0`, so lockstep is the established practice.