### PR TITLE
docs: clarify precompile table and limit hot-path comments

### DIFF
--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -1650,7 +1650,13 @@ pub mod storage_gas_ext {
     }
 }
 
-/// Compute gas recording implementation. TODO: add more doc
+/// Per-opcode compute-gas recording wrappers.
+///
+/// Each opcode is wrapped so the compute gas it consumes (`gas_before - gas_after`, minus any
+/// gas forwarded to a child frame for the call/create family) is recorded into the compute-gas
+/// dimension of `AdditionalLimit` after the inner instruction runs. The `wrap_op_compute_gas`
+/// macro below defines the `default` and `@frame` variants; `SELFDESTRUCT` uses a dedicated
+/// wrapper whose trailing check fans out across all four limit dimensions.
 pub mod compute_gas_ext {
     use super::*;
 

--- a/crates/mega-evm/src/evm/precompiles.rs
+++ b/crates/mega-evm/src/evm/precompiles.rs
@@ -52,13 +52,14 @@ impl MegaPrecompiles {
         Self { inner: EthPrecompiles { precompiles: inner, spec: spec.into_eth_spec() }, spec }
     }
 
-    /// Get the precompiles for the current spec.
+    /// Returns the static base precompile table selected for this provider's spec.
     ///
-    /// This method returns precompiles with custom gas cost overrides for `MINI_REX` spec.
+    /// The MegaETH precompile gas-cost overrides (the fixed-cost KZG point evaluation and the
+    /// Osaka ModExp schedule) are baked into the table itself by [`mini_rex`] / [`rex`]; the
+    /// per-spec compute-gas accounting and the REX5 forwarded-gas cap are applied separately in
+    /// the `run()` method, not here.
     #[inline]
     pub fn precompiles(&self) -> &'static Precompiles {
-        // For now, just use the inner precompiles
-        // Custom gas costs will be applied in the run() method
         self.inner.precompiles
     }
 }

--- a/crates/mega-evm/src/limit/limit.rs
+++ b/crates/mega-evm/src/limit/limit.rs
@@ -569,6 +569,12 @@ impl AdditionalLimit {
             self.data_size.after_frame_init_on_frame(frame);
             self.kv_update.after_frame_init_on_frame(frame);
             self.compute_gas.after_frame_init_on_frame(frame);
+            // Deliberately no `check_limit()` here: this records the child frame's init growth
+            // (e.g. the CREATE account-info write), but `before_frame_run` runs `check_limit()`
+            // before the frame's first metered opcode executes. Per the Resource-Limit Check
+            // Protocol, that latches any exceed ahead of the first `record_compute_gas`, so a
+            // latch here would be redundant. The deferral is sound only because this fixed
+            // lifecycle order (after_frame_init → before_frame_run → first opcode) is guaranteed.
         } else if let ItemOrResult::Result(result) = init_result {
             // Rescue gas if a TX-level limit was exceeded. This covers the
             // before_frame_init early-return path and any other Result from frame_init.


### PR DESCRIPTION
## Summary

Documentation/comment-only cleanup of three spots in the precompile provider and the EVM hot path.
No behavior change: no spec semantics, gas accounting, or control flow is touched.

## Changes

- `MegaPrecompiles::precompiles()` (`evm/precompiles.rs`): the doc claimed it "returns precompiles with custom gas cost overrides for MINI_REX spec" while the body just returned the inner table under a `// For now` note.
  Rewrote it to state accurately that the precompile gas-cost overrides (fixed-cost KZG point evaluation, Osaka ModExp schedule) are baked into the table by `mini_rex()` / `rex()`, while the per-spec compute-gas accounting and the REX5 forwarded-gas cap are applied separately in `run()`.
- `AdditionalLimit::after_frame_init` (`limit/limit.rs`): added a comment explaining why this site records the child frame's init growth without calling `check_limit()` itself.
  `before_frame_run` latches any exceed before the first metered opcode, so the deferral is sound under the fixed frame lifecycle order (per the Resource-Limit Check Protocol).
  This is the one frame-lifecycle hook that defers its latch, so the reasoning is now written down.
- `compute_gas_ext` module (`evm/instructions.rs`): replaced the `TODO: add more doc` placeholder with a real module doc describing the per-opcode compute-gas wrappers and the `default` / `@frame` / `SELFDESTRUCT` variants.

## Testing

- `cargo fmt --all --check`: clean.
- Doc/comment-only change with no compilation or runtime impact; existing tests are unaffected.
