### PR TITLE
ci(benchmark): relink-floor probe — semantically inert fn reorder

### DIFF
--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -1162,12 +1162,6 @@ pub mod storage_gas_ext {
     use super::*;
     use alloy_primitives::Address;
 
-    /// Address-selector for opcodes where the storage account is the stack `to` address (e.g.
-    /// CALL).
-    fn storage_addr_from_to(_mega_spec: MegaSpecId, _current: Address, to: Address) -> Address {
-        to
-    }
-
     /// Address-selector for CALLCODE: Rex5+ uses the current frame's address because CALLCODE
     /// executes borrowed code in the caller's own storage context; pre-Rex5 preserves the frozen
     /// behavior of metering against the code-source (stack `to`).
@@ -1177,6 +1171,12 @@ pub mod storage_gas_ext {
         } else {
             to
         }
+    }
+
+    /// Address-selector for opcodes where the storage account is the stack `to` address (e.g.
+    /// CALL).
+    fn storage_addr_from_to(_mega_spec: MegaSpecId, _current: Address, to: Address) -> Address {
+        to
     }
 
     /// Macro to charge storage gas for new account creation before calling the wrapped instruction.


### PR DESCRIPTION
## Summary
- Swap the definition order of two adjacent private address-selector helpers in `storage_gas_ext` (`instructions.rs`). Zero semantic change; the only effect is a code-layout shift in the rebuilt binary — the same class of shift any small PR causes.
- Purpose: an A/A' floor measurement for the bench CI. Feature and baseline are semantically identical here, so **every "significant" row `/benchmark` reports on this PR is inter-binary layout / link-order noise** — the relink floor that the in-band A/A gate (same-binary round jitter) cannot see.
- Motivation: the `/benchmark` run on #326 flagged +2–11% "significant regressions" on lanes that never execute the changed code (`sstore_heavy/revm_pinned/sload_100` +7.9%, `subcall_1000_transfer_1wei/revm_pinned` +8.7%, `snailtracer/revm_latest` +11.4%). Either the suite's relink floor really is that high — in which case ±5% verdicts on any small PR are unreliable and the gate needs a relink-floor term — or something else is wrong in the comparison path. This probe decides which.

## Test plan
- `cargo check -p mega-evm` green (pure reorder, no behavior change).
- Run `/benchmark` on this PR and read the significant-changes table as the relink floor:
  - many ±2–8% significant rows → floor confirmed; follow-ups are function-alignment flags for bench builds and a relink-floor term in the significance gate;
  - clean (≈0 significant) → layout is not the explanation for #326's contradictions and its regressions need a different explanation.
- Not meant to merge; close after recording the floor.