### PR TITLE
bench: rex5 shared lane + verdict-first comparison comment

### DIFF
--- a/.github/scripts/bench_compare.py
+++ b/.github/scripts/bench_compare.py
@@ -362,11 +362,9 @@ def ci_str(c: Comparison) -> str:
 
 
 def row_str(c: Comparison, label: str) -> str:
-    b_us = f"{c.baseline_ns / 1000:.1f} µs"
-    f_us = f"{c.feature_ns / 1000:.1f} µs"
     sign = "+" if c.mean_delta > 0 else ""
-    return (f"| {label} | {b_us} | {f_us} | {sign}{c.mean_delta:.1f}% "
-            f"| {ci_str(c)} | ±{c.floor:.1f}% | {icon(c)} |")
+    return (f"| {label} | {format_time(c.baseline_ns)} | {format_time(c.feature_ns)} "
+            f"| {sign}{c.mean_delta:.1f}% | {ci_str(c)} | ±{c.floor:.1f}% | {icon(c)} |")
 
 
 TABLE_HEADER = (
@@ -375,28 +373,55 @@ TABLE_HEADER = (
 )
 
 LEGEND = (
-    "\n_:rocket: significant speedup · :x:/:warning: significant regression · "
+    "_:rocket: significant speedup · :x:/:warning: significant regression · "
     ":eyes: directional but below the A/A noise floor · :white_circle: within "
-    "noise. **Significant = 95% bootstrap CI excludes 0 AND |Δ| > the A/A "
-    "floor** (that bench's own round-to-round jitter)._\n"
+    "noise._\n"
 )
+
+METHODOLOGY = (
+    "**Paired, order-interleaved A/B.** Each round runs the feature and "
+    "baseline binaries back-to-back on the same runner; the verdict is the "
+    "mean of the per-round paired Δ% with a 95% bootstrap CI over the "
+    "rounds. A change is flagged only when its **CI excludes 0 _and_ |Δ| "
+    "clears the bench's A/A noise floor** (that bench's own round-to-round "
+    "jitter), so minutes-apart machine drift no longer reads as a regression "
+    "and a real sub-5% change is no longer buried in it.\n\n" + LEGEND
+)
+
+# Lanes that run upstream revm / op-revm, not this repo's EVM code. A PR that
+# doesn't touch the bench harness or vendored dependencies cannot change what
+# these lanes execute — so a significant delta on them measures the
+# binary-layout / link-order difference between the two builds (the relink
+# floor), not the change under review.
+CONTROL_SPECS = {"revm_pinned", "revm_latest", "op_revm_pinned", "op_revm_latest"}
+
+# Significant rows shown expanded; the rest fold into a <details>.
+TOP_SIGNIFICANT = 15
+
+
+def _is_control(label: str) -> bool:
+    return any(seg in CONTROL_SPECS for seg in label.split("/"))
+
+
+def _details(summary: str, inner: str) -> str:
+    return f"<details><summary>{summary}</summary>\n\n{inner}\n</details>\n\n"
+
+
+def _table(cs, label_of) -> str:
+    return TABLE_HEADER + "\n".join(row_str(c, label_of[id(c)]) for c in cs) + "\n"
 
 
 def render(comparisons, feature_rounds, feature_sha, baseline_sha, repo_url,
            aa_check: bool) -> str:
+    """One screen tells the verdict; everything long folds into <details>.
+
+    Order: header → headline counts → relink-floor hint (when control lanes
+    flag) → significant table (worst first, top rows expanded) → folded
+    baseline-gap / full-table / methodology sections."""
     body = "## Criterion Benchmark Comparison\n\n"
     body += (
         f"> Comparing [`baseline`]({repo_url}/commit/{baseline_sha})"
         f" → [`feature`]({repo_url}/commit/{feature_sha})\n\n"
-    )
-    body += (
-        "> **Paired, order-interleaved A/B.** Each round runs the feature and "
-        "baseline binaries back-to-back on the same runner; the verdict is the "
-        "mean of the per-round paired Δ% with a 95% bootstrap CI over the "
-        "rounds. A change is flagged only when its **CI excludes 0 _and_ |Δ| "
-        "clears the bench's A/A noise floor**, so minutes-apart machine drift no "
-        "longer reads as a regression and a real sub-5% change is no longer "
-        "buried in it.\n\n"
     )
 
     if aa_check:
@@ -408,20 +433,19 @@ def render(comparisons, feature_rounds, feature_sha, baseline_sha, repo_url,
         )
 
     gap = baseline_gap_section(feature_rounds)
+    gap_section = ""
     if gap:
-        body += "### Baseline gap (HEAD only — how far is each EVM layer from `revm_pinned`)\n"
-        body += (
-            "\n_Read the highest `rex*` row (currently `rex5`, the latest spec) "
+        gap_section = _details(
+            "Baseline gap — each EVM layer vs <code>revm_pinned</code> (HEAD only)",
+            "_Read the highest `rex*` row (currently `rex5`, the latest spec) "
             'for the "user-visible mega gap"; the earlier `rex*` rows are prior '
-            "specs. The non-`rex` rows are diagnostic: they show which layer adds "
-            "cost._\n"
+            "specs. The non-`rex` rows are diagnostic: they show which layer "
+            "adds cost._\n" + gap,
         )
-        body += gap
-        body += "\n---\n\n### PR-base → PR-head regression check\n\n"
 
     if not comparisons:
-        body += "_No comparable benchmarks found._\n"
-        return body
+        body += "_No comparable benchmarks found._\n\n"
+        return body + gap_section
 
     comparisons = sorted(comparisons, key=lambda c: (c.name, c.target))
     # Only prefix the target when the same bench name came from more than one
@@ -438,28 +462,51 @@ def render(comparisons, feature_rounds, feature_sha, baseline_sha, repo_url,
     improvements = sum(1 for c in comparisons if c.improved)
     noise_limited = sum(1 for c in comparisons if c.noise_limited)
     significant = [c for c in comparisons if c.significant]
-    rows = [row_str(c, label_of[id(c)]) for c in comparisons]
-
-    if len(rows) > 20 and 0 < len(significant) < len(rows):
-        body += (
-            f"<details><summary>{len(rows)} benchmarks total, "
-            f"{len(significant)} significant</summary>\n\n"
-        )
-        body += TABLE_HEADER + "\n".join(rows) + "\n\n</details>\n\n"
-        body += "**Significant changes:**\n\n"
-        body += TABLE_HEADER + "\n".join(row_str(c, label_of[id(c)]) for c in significant) + "\n"
-    else:
-        body += TABLE_HEADER + "\n".join(rows) + "\n"
-
-    body += LEGEND
+    within = len(comparisons) - len(significant) - noise_limited
     n_rounds = max((c.n_pairs for c in comparisons), default=0)
-    within = len(rows) - len(significant) - noise_limited
+
+    # The verdict, first — the counts used to sit at the very bottom.
     body += (
-        f"\n**{len(rows)} benchmarks** (paired over up to {n_rounds} rounds): "
-        f"{regressions} significant regressions, {improvements} significant "
-        f"improvements, {noise_limited} directional-but-noise-limited, "
-        f"{within} within noise\n"
+        f"**{len(comparisons)} benchmarks · up to {n_rounds} paired rounds** — "
+        f"{regressions} :warning: significant regressions · "
+        f"{improvements} :rocket: significant improvements · "
+        f"{noise_limited} :eyes: noise-limited · "
+        f"{within} :white_circle: within noise\n\n"
     )
+
+    ctrl = [c for c in significant if _is_control(label_of[id(c)])]
+    if ctrl and not aa_check:
+        worst = max(ctrl, key=lambda c: abs(c.mean_delta))
+        body += (
+            f"> :straight_ruler: **Relink-floor hint:** {len(ctrl)} significant "
+            f"row(s) sit on upstream control lanes (`revm_*` / `op_revm_*`), "
+            f"worst {worst.mean_delta:+.1f}% on `{label_of[id(worst)]}`. Those "
+            "lanes do not execute this repo's EVM code — unless the PR touches "
+            "the bench harness or vendored dependencies, a significant delta "
+            "there measures binary-layout / link-order noise between the two "
+            "builds, and same-magnitude findings on mega lanes should be read "
+            "against that floor.\n\n"
+        )
+
+    if significant:
+        by_impact = sorted(significant, key=lambda c: -abs(c.mean_delta))
+        head, tail = by_impact[:TOP_SIGNIFICANT], by_impact[TOP_SIGNIFICANT:]
+        body += "### Significant changes (worst first)\n\n"
+        body += _table(head, label_of) + "\n"
+        if tail:
+            body += _details(f"{len(tail)} more significant rows",
+                             _table(tail, label_of))
+        body += LEGEND + "\n"
+    else:
+        body += (
+            "**No significant changes** — no bench cleared both the bootstrap "
+            "CI and its A/A noise floor.\n\n"
+        )
+
+    body += gap_section
+    body += _details(f"All {len(comparisons)} comparisons",
+                     _table(comparisons, label_of))
+    body += _details("Methodology", METHODOLOGY)
     return body
 
 

--- a/.github/scripts/bench_compare.py
+++ b/.github/scripts/bench_compare.py
@@ -495,7 +495,11 @@ def render(comparisons, feature_rounds, feature_sha, baseline_sha, repo_url,
         )
 
     if significant:
-        by_impact = sorted(significant, key=lambda c: -abs(c.mean_delta))
+        # Regressions strictly before improvements (each worst-first): ranking
+        # by |Δ| alone would let a stack of big speedups push a real +6%
+        # regression below the fold — the one row a reviewer must not miss.
+        by_impact = sorted(significant,
+                           key=lambda c: (c.improved, -abs(c.mean_delta)))
         head, tail = by_impact[:TOP_SIGNIFICANT], by_impact[TOP_SIGNIFICANT:]
         body += "### Significant changes (worst first)\n\n"
         body += _table(head, label_of) + "\n"

--- a/.github/scripts/bench_compare.py
+++ b/.github/scripts/bench_compare.py
@@ -398,6 +398,12 @@ CONTROL_SPECS = {"revm_pinned", "revm_latest", "op_revm_pinned", "op_revm_latest
 # Significant rows shown expanded; the rest fold into a <details>.
 TOP_SIGNIFICANT = 15
 
+# GitHub caps issue comments at 65536 characters; stay comfortably under it by
+# dropping the bulkiest folded sections (full table first, then baseline gap)
+# instead of failing the post. The raw round files ride in the run artifact
+# either way. Env-overridable so tests can exercise the drop path.
+MAX_COMMENT_CHARS = int(os.environ.get("MAX_COMMENT_CHARS", "60000"))
+
 
 def _is_control(label: str) -> bool:
     return any(seg in CONTROL_SPECS for seg in label.split("/"))
@@ -503,10 +509,29 @@ def render(comparisons, feature_rounds, feature_sha, baseline_sha, repo_url,
             "CI and its A/A noise floor.\n\n"
         )
 
-    body += gap_section
-    body += _details(f"All {len(comparisons)} comparisons",
-                     _table(comparisons, label_of))
-    body += _details("Methodology", METHODOLOGY)
+    # Folded bulk, dropped last-first when the comment would blow the size cap:
+    # the full table goes before the baseline gap (it is the least-read — the
+    # significant rows are already shown and the rounds live in the artifact).
+    optional = []
+    if gap_section:
+        optional.append(("the baseline-gap tables", gap_section))
+    optional.append((f"the all-{len(comparisons)}-comparisons table",
+                     _details(f"All {len(comparisons)} comparisons",
+                              _table(comparisons, label_of))))
+    methodology = _details("Methodology", METHODOLOGY)
+    dropped = []
+    while optional and (len(body) + sum(len(s) for _, s in optional)
+                        + len(methodology) > MAX_COMMENT_CHARS):
+        dropped.append(optional.pop()[0])
+    for _, section in optional:
+        body += section
+    body += methodology
+    if dropped:
+        body += (
+            f"_Dropped to fit GitHub's comment size limit: "
+            f"{', '.join(reversed(dropped))}. The complete data is in the "
+            "run's `criterion-benchmark-results` artifact._\n"
+        )
     return body
 
 

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,9 +17,11 @@ on:
 # group + cancel-in-progress an unrelated comment lands in the same group and
 # cancels a live benchmark mid-flight. Non-trigger comment runs now share their
 # own group and only ever cancel each other; real runs still debounce real
-# re-triggers.
+# re-triggers. The author gate mirrors the prepare job's `if` — without it an
+# UNAUTHORIZED `/benchmark` would cancel a live run and then skip at the guard
+# (a benchmark-DoS on public PRs); keep the two predicates in sync.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || contains(github.event.comment.body, '/benchmark') }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (contains(github.event.comment.body, '/benchmark') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')) }}
   cancel-in-progress: true
 
 # Paired, order-interleaved A/B knobs. The harness runs the feature and baseline

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -227,6 +227,13 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # 64-byte (2^6) function alignment: cache-line-aligned function
+          # starts remove the largest layout-noise term a relink can inject
+          # into the A/B comparison (complements the bench profile's single
+          # codegen unit; replaces the action's default `-D warnings`, which
+          # measurement builds don't need).
+          rustflags: -C llvm-args=-align-all-functions=6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,11 +17,12 @@ on:
 # group + cancel-in-progress an unrelated comment lands in the same group and
 # cancels a live benchmark mid-flight. Non-trigger comment runs now share their
 # own group and only ever cancel each other; real runs still debounce real
-# re-triggers. The author gate mirrors the prepare job's `if` — without it an
-# UNAUTHORIZED `/benchmark` would cancel a live run and then skip at the guard
-# (a benchmark-DoS on public PRs); keep the two predicates in sync.
+# re-triggers. The suffix mirrors the prepare job's FULL trigger gate
+# (PR-comment + /benchmark + author association) — any comment that would fail
+# the gate must not share a group with real runs, or it cancels a live run it
+# cannot replace (a benchmark-DoS on public PRs); keep the two in sync.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (contains(github.event.comment.body, '/benchmark') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')) }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, '/benchmark') && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.comment.author_association)) }}
   cancel-in-progress: true
 
 # Paired, order-interleaved A/B knobs. The harness runs the feature and baseline
@@ -166,7 +167,8 @@ jobs:
             const issue_number = context.payload.issue.number;
             const comments = await github.paginate(github.rest.issues.listComments,
               { owner, repo, issue_number, per_page: 100 });
-            const mine = comments.filter(c => c.body && c.body.includes(marker)).pop();
+            const mine = comments.filter(c => c.user && c.user.login === 'github-actions[bot]'
+              && c.body && c.body.includes(marker)).pop();
             if (mine) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
             } else {
@@ -311,12 +313,14 @@ jobs:
     needs: [prepare, bench]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # `always()` so a failed bench leg still updates the status comment (which
-    # would otherwise sit at "in progress" forever) — partial rounds are
-    # aggregated and the comment gets a warning banner instead.
+    # `!cancelled()` (NOT `always()`): a failed bench leg still updates the
+    # status comment (partial rounds aggregated under a warning banner), but a
+    # CANCELLED run must not run compare — the newer run that cancelled it owns
+    # the shared comment now, and `always()` would overwrite its fresh
+    # "in progress" status with this run's stale partial report.
     if: >-
-      always() && needs.prepare.result == 'success' &&
-      needs.prepare.outputs.compare == 'true'
+      ${{ !cancelled() && needs.prepare.result == 'success' &&
+          needs.prepare.outputs.compare == 'true' }}
     # Posts the comparison comment; consumes artifacts plus the TRUSTED base-repo
     # aggregation script (checked out below from the default branch, never PR
     # code).
@@ -384,7 +388,8 @@ jobs:
             const issue_number = context.issue.number;
             const comments = await github.paginate(github.rest.issues.listComments,
               { owner, repo, issue_number, per_page: 100 });
-            const mine = comments.filter(c => c.body && c.body.includes(marker)).pop();
+            const mine = comments.filter(c => c.user && c.user.login === 'github-actions[bot]'
+              && c.body && c.body.includes(marker)).pop();
             if (mine) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
             } else {

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -134,6 +134,43 @@ jobs:
               core.warning(`could not add :rocket: reaction: ${e.message}`);
             }
 
+      # Claim/refresh THE report comment right away: it names the action run so
+      # a watcher knows where the benchmark lives, and the compare job later
+      # edits this same comment in place — repeated /benchmark runs never stack
+      # a second giant report. Best-effort: a failed post must not skip bench.
+      - name: Post in-progress status comment
+        if: github.event_name == 'issue_comment'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        env:
+          FEATURE_SHA: ${{ steps.resolve.outputs.feature_sha }}
+          BASELINE_SHA: ${{ steps.resolve.outputs.baseline_sha }}
+        with:
+          script: |
+            const marker = '<!-- criterion-benchmark-report -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const short = (s) => (s || '').slice(0, 12);
+            const body = [
+              marker,
+              '## Criterion Benchmark Comparison',
+              '',
+              `:hourglass_flowing_sand: **Benchmark in progress** — [watch the run](${runUrl})`,
+              '',
+              `Comparing \`${short(process.env.BASELINE_SHA)}\` (baseline) → ` +
+                `\`${short(process.env.FEATURE_SHA)}\` (feature). ` +
+                'This comment is updated in place when the run finishes.',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 });
+            const mine = comments.filter(c => c.body && c.body.includes(marker)).pop();
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
   # One job per bench target. Each job builds BOTH the feature and baseline bench
   # binaries up front (no rebuild during measurement), then runs them paired and
   # order-interleaved on the SAME runner for BENCH_ROUNDS short rounds. Pairing
@@ -272,7 +309,12 @@ jobs:
     needs: [prepare, bench]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    if: needs.prepare.outputs.compare == 'true'
+    # `always()` so a failed bench leg still updates the status comment (which
+    # would otherwise sit at "in progress" forever) — partial rounds are
+    # aggregated and the comment gets a warning banner instead.
+    if: >-
+      always() && needs.prepare.result == 'success' &&
+      needs.prepare.outputs.compare == 'true'
     # Posts the comparison comment; consumes artifacts plus the TRUSTED base-repo
     # aggregation script (checked out below from the default branch, never PR
     # code).
@@ -285,6 +327,9 @@ jobs:
           fetch-depth: 1
 
       - name: Download all round results
+        # May find nothing when every bench leg failed; the aggregate step
+        # tolerates an empty dir and the comment step banners the failure.
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           pattern: bench-rounds-*
@@ -307,19 +352,42 @@ jobs:
           mkdir -p all_rounds
           python3 .github/scripts/bench_compare.py
 
+      # Update the status comment the prepare job claimed (create if it is
+      # somehow missing) — one report comment per PR, edited in place, never a
+      # growing stack of giant comments.
       - name: Comment on PR
         if: github.event_name == 'issue_comment'
         uses: actions/github-script@v7
+        env:
+          BENCH_RESULT: ${{ needs.bench.result }}
         with:
           script: |
             const fs = require('fs');
-            const body = fs.readFileSync('comparison.md', 'utf8');
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body,
-            });
+            const marker = '<!-- criterion-benchmark-report -->';
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            let report;
+            try {
+              report = fs.readFileSync('comparison.md', 'utf8');
+            } catch (e) {
+              report = '## Criterion Benchmark Comparison\n\n_No comparison was produced._\n';
+            }
+            let banner = '';
+            if (process.env.BENCH_RESULT !== 'success') {
+              banner = `> :warning: **Some bench jobs did not succeed** ` +
+                `(bench: \`${process.env.BENCH_RESULT}\`) — results below may be ` +
+                `partial; see the [run log](${runUrl}).\n\n`;
+            }
+            const body = `${marker}\n${banner}${report}\n_Produced by [this run](${runUrl})._`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.paginate(github.rest.issues.listComments,
+              { owner, repo, issue_number, per_page: 100 });
+            const mine = comments.filter(c => c.body && c.body.includes(marker)).pop();
+            if (mine) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: mine.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
 
       - name: Upload comparison
         if: always()

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -12,8 +12,14 @@ on:
   issue_comment:
     types: [created]
 
+# The group is suffixed with "is this a real trigger": issue_comment fires for
+# EVERY new comment (codecov, mutation bots, humans chatting), and with a single
+# group + cancel-in-progress an unrelated comment lands in the same group and
+# cancels a live benchmark mid-flight. Non-trigger comment runs now share their
+# own group and only ever cancel each other; real runs still debounce real
+# re-triggers.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || contains(github.event.comment.body, '/benchmark') }}
   cancel-in-progress: true
 
 # Paired, order-interleaved A/B knobs. The harness runs the feature and baseline

--- a/.github/workflows/replay-bench.yml
+++ b/.github/workflows/replay-bench.yml
@@ -18,8 +18,11 @@ on:
   issue_comment:
     types: [created]
 
+# Suffixed with "is this a real trigger" so unrelated comments (bots, chat)
+# land in their own group instead of cancelling a live run — same fix as
+# benchmark.yml.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || contains(github.event.comment.body, '/replay-bench') }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/replay-bench.yml
+++ b/.github/workflows/replay-bench.yml
@@ -20,9 +20,10 @@ on:
 
 # Suffixed with "is this a real trigger" so unrelated comments (bots, chat)
 # land in their own group instead of cancelling a live run — same fix as
-# benchmark.yml.
+# benchmark.yml, including the author gate (an unauthorized `/replay-bench`
+# must not cancel a live run it cannot replace).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || contains(github.event.comment.body, '/replay-bench') }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (contains(github.event.comment.body, '/replay-bench') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')) }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/replay-bench.yml
+++ b/.github/workflows/replay-bench.yml
@@ -20,10 +20,11 @@ on:
 
 # Suffixed with "is this a real trigger" so unrelated comments (bots, chat)
 # land in their own group instead of cancelling a live run — same fix as
-# benchmark.yml, including the author gate (an unauthorized `/replay-bench`
-# must not cancel a live run it cannot replace).
+# benchmark.yml: mirror the FULL trigger gate (PR-comment + /replay-bench +
+# author association); a comment that would fail the gate must not cancel a
+# live run it cannot replace.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (contains(github.event.comment.body, '/replay-bench') && (github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'OWNER')) }}
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.ref }}-${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, '/replay-bench') && contains(fromJSON('["MEMBER","COLLABORATOR","OWNER"]'), github.event.comment.author_association)) }}
   cancel-in-progress: true
 
 permissions:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -214,6 +214,18 @@ strip = "symbols"
 panic = "unwind"
 codegen-units = 16
 
+# Bench builds must be layout-STABLE, not just fast: with release's 16
+# codegen units + thin LTO, any code change reshuffles function layout
+# binary-wide, and a paired A/B across two builds then measures the
+# reshuffle — a semantically-inert change can read as a multi-percent
+# "significant" delta, including on benches that never execute the changed
+# code. One codegen unit makes intra-crate code placement deterministic
+# given the same source; the bench workflow adds 64-byte function alignment
+# on top. Slower to compile — benches build once per CI side, so the cost
+# is minutes.
+[profile.bench]
+codegen-units = 1
+
 # Use the `--profile profiling` flag to show symbols in release mode.
 # e.g. `cargo build --profile profiling`
 [profile.profiling]

--- a/crates/mega-evm/benches/common/mod.rs
+++ b/crates/mega-evm/benches/common/mod.rs
@@ -28,6 +28,7 @@ pub const SPEC_IDS: &[(&str, MegaSpecId)] = &[
     ("equivalence", MegaSpecId::EQUIVALENCE),
     ("mini_rex", MegaSpecId::MINI_REX),
     ("rex4", MegaSpecId::REX4),
+    ("rex5", MegaSpecId::REX5),
 ];
 
 type Group<'a> = criterion::BenchmarkGroup<'a, criterion::measurement::WallTime>;


### PR DESCRIPTION
## Summary
- `benches/common`: add `rex5` to the shared `SPEC_IDS` list. Every bench going through `register_all`/`register_mega` (`sstore_heavy`, `oracle_sload`, `create_deploy`, `call_value_empty_account`, `log_opcodes`, `mixed_workload`, `snailtracer`, `subcall_*`, …) topped out at `rex4`, so the latest spec had no lane exactly where storage/host optimizations land. Benches passing explicit lists (`system_contract`, `eip7702_authlist`, `comp_cost`, …) already carried `rex5`; this brings the shared list in line. Adds ~34 rows to the suite.
- `bench_compare.py`: restructure the `/benchmark` comment so one screen tells the verdict — headline counts first; significant changes worst-first with the top 15 expanded and the rest folded; the baseline-gap tables, the full comparison table, and the methodology prose each fold into their own `<details>`. ms-scale rows render as `143.40 ms` instead of `143403.2 µs`.
- New relink-floor hint: when significant rows land on upstream control lanes (`revm_*`/`op_revm_*`) that do not execute this repo's EVM code, the comment says so explicitly — significance there measures binary-layout/link-order noise between the two builds, and same-magnitude mega-lane findings must be read against that floor (see #335 for the probe quantifying it).

## Test plan
- `cargo check --benches -p mega-evm` green with the rex5 lane.
- `bench_compare.py` exercised against synthetic round files: verdict line, worst-first ordering, top-15/tail fold, control-lane hint, ms formatting, baseline-gap/full-table/methodology folds, and the A/A self-check mode (hint suppressed) all verified on rendered output.
- Comment rendering takes effect on the next `/benchmark` run after merge.