### PR TITLE
ci(codspeed): adopt instruction-count benchmarks via CodSpeed simulation

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -227,13 +227,6 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          # 64-byte (2^6) function alignment: cache-line-aligned function
-          # starts remove the largest layout-noise term a relink can inject
-          # into the A/B comparison (complements the bench profile's single
-          # codegen unit; replaces the action's default `-D warnings`, which
-          # measurement builds don't need).
-          rustflags: -C llvm-args=-align-all-functions=6
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -227,6 +227,12 @@ jobs:
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # Empty rustflags overrides this action's default `-D warnings`.
+          # Measurement builds should not fail on unrelated warnings; the
+          # previous align-all-functions flag is gone (layout stabilization
+          # was ineffective), but the opt-out of `-D warnings` stays.
+          rustflags: ""
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,7 +53,7 @@ jobs:
   # cannot make different jobs measure different code (or mislabel the result).
   prepare:
     name: Resolve commits
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     # Reacts to the triggering comment; does not execute PR code.
     # `issues: write` is required to react to the (issue) comment — PR
@@ -184,11 +184,11 @@ jobs:
   bench:
     name: Bench ${{ matrix.target }}
     needs: prepare
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     # Paired interleaving runs each round's measurement ~1.5x the old single
     # pass, and re-pays per-bench setup once per round; give heavy-setup targets
-    # (block_bench / attack_replay / comp_cost) generous headroom. Well under the
-    # 6h hosted-runner job cap. Lower BENCH_ROUNDS in env to trade back time.
+    # (block_bench / attack_replay / comp_cost) generous headroom. Lower
+    # BENCH_ROUNDS in env to trade back time.
     timeout-minutes: 180
     # This job compiles and runs untrusted PR code — keep it read-only so there
     # is no write-scoped token to exfiltrate. `pull-requests: read` lets
@@ -317,7 +317,7 @@ jobs:
   compare:
     name: Compare and comment on PR
     needs: [prepare, bench]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     # `!cancelled()` (NOT `always()`): a failed bench leg still updates the
     # status comment (partial rounds aggregated under a warning banner), but a

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -21,7 +21,10 @@ permissions:
 
 concurrency:
   group: codspeed-${{ github.ref }}
-  cancel-in-progress: true
+  # PR runs coalesce (only the newest push matters), but every main push is a
+  # baseline datapoint — cancelling one mid-flight leaves a gap CodSpeed must
+  # bridge from an older ancestor. Queue main runs instead of cancelling.
+  cancel-in-progress: ${{ github.ref_name != 'main' }}
 
 jobs:
   codspeed:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -38,10 +38,20 @@ jobs:
           submodules: recursive
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          # The explicit rust-cache step below owns caching (matrix-shared key).
+          cache: false
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+        with:
+          # Shared across the 7 matrix legs so a cold workspace build is paid once.
+          shared-key: codspeed
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install cargo-codspeed
-        run: cargo install cargo-codspeed --locked --version 5.0.1
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-codspeed@5.0.1
       - name: Build benches under instrumentation
         run: cargo codspeed build -p mega-evm --bench ${{ matrix.target }}
       - name: Run benches

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
   pull_request:
     # Only paths that can move instruction counts (benches, sources, deps,
-    # toolchain, or this workflow itself) — doc-only PRs skip the matrix.
+    # toolchain, or this workflow itself) — doc-only PRs skip the run.
     paths:
       - "crates/**"
       - "bin/**"
@@ -25,15 +25,11 @@ concurrency:
 
 jobs:
   codspeed:
-    name: instruction count (${{ matrix.target }})
+    name: instruction count
     runs-on: ubuntu-24.04
-    # Measured on the first full runs: a cold leg finishes in ~12 min, a warm
-    # one in 2–7 min — 30 min is ample headroom.
+    # A cold full-suite run measures in at ~13 min (simulation mode executes
+    # each bench once — no criterion sampling loop) — 30 min is ample headroom.
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        target: [revm_bench, mega_bench, block_bench, transact, comp_cost, ctt, attack_replay]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,25 +37,20 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          # The explicit rust-cache step below owns caching (matrix-shared key).
-          cache: false
           # Empty rustflags overrides this action's default `-D warnings` —
           # measurement builds should not fail on unrelated warnings (clippy CI
           # is the warnings gate). Mirrors benchmark.yml.
           rustflags: ""
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@v2
-        with:
-          # Shared across the 7 matrix legs so a cold workspace build is paid once.
-          shared-key: codspeed
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-codspeed@5.0.1
+      # No --bench filter: every bench target in the crate is built, so newly
+      # added bench targets are picked up without touching this workflow.
       - name: Build benches under instrumentation
-        run: cargo codspeed build -p mega-evm --bench ${{ matrix.target }}
+        run: cargo codspeed build -p mega-evm
       - name: Run benches
         uses: CodSpeedHQ/action@v4
         with:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -34,6 +34,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
+          # Drop the checkout token from .git/config after fetch so the bench
+          # build/run steps (which execute crate build scripts) cannot read it.
+          persist-credentials: false
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -46,6 +49,9 @@ jobs:
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2
         with:
+          # The CLI and the codspeed-criterion-compat crate are released in
+          # lockstep and must agree on the major version — keep this pin in
+          # sync with the `criterion` dev-dependency in crates/mega-evm.
           tool: cargo-codspeed@5.0.1
       # No --bench filter: every bench target in the crate is built, so newly
       # added bench targets are picked up without touching this workflow.

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Only paths that can move instruction counts (benches, sources, deps,
+    # toolchain, or this workflow itself) — doc-only PRs skip the matrix.
+    paths:
+      - "crates/**"
+      - "bin/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - "rust-toolchain.toml"
+      - ".github/workflows/codspeed.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -1,0 +1,42 @@
+name: CodSpeed
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write   # OIDC auth — public repo, no token secret needed
+
+concurrency:
+  group: codspeed-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codspeed:
+    name: instruction count (${{ matrix.target }})
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [revm_bench, mega_bench, block_bench, transact, comp_cost, ctt, attack_replay]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+      - name: Install cargo-codspeed
+        run: cargo install cargo-codspeed --locked --version 5.0.1
+      - name: Build benches under instrumentation
+        run: cargo codspeed build -p mega-evm --bench ${{ matrix.target }}
+      - name: Run benches
+        uses: CodSpeedHQ/action@v4
+        with:
+          mode: simulation
+          run: cargo codspeed run

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -26,9 +26,10 @@ concurrency:
 jobs:
   codspeed:
     name: instruction count
-    runs-on: ubuntu-24.04
-    # A cold full-suite run measures in at ~13 min (simulation mode executes
-    # each bench once — no criterion sampling loop) — 30 min is ample headroom.
+    runs-on: blacksmith-32vcpu-ubuntu-2404
+    # A cold full-suite run measured ~13 min on a GitHub-hosted 4-vCPU runner
+    # (simulation mode executes each bench once — no criterion sampling loop);
+    # the 32vcpu runner only shortens the build — 30 min is ample headroom.
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -27,7 +27,9 @@ jobs:
   codspeed:
     name: instruction count (${{ matrix.target }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 90
+    # Measured on the first full runs: a cold leg finishes in ~12 min, a warm
+    # one in 2–7 min — 30 min is ample headroom.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -41,6 +43,10 @@ jobs:
         with:
           # The explicit rust-cache step below owns caching (matrix-shared key).
           cache: false
+          # Empty rustflags overrides this action's default `-D warnings` —
+          # measurement builds should not fail on unrelated warnings (clippy CI
+          # is the warnings gate). Mirrors benchmark.yml.
+          rustflags: ""
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/replay-bench.yml
+++ b/.github/workflows/replay-bench.yml
@@ -36,7 +36,7 @@ jobs:
   # PR code (or even a PR-controlled ref) into the workspace.
   prepare:
     name: Resolve commits
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     permissions:
       contents: read
@@ -104,7 +104,7 @@ jobs:
   bench:
     name: Replay throughput
     needs: prepare
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-32vcpu-ubuntu-2404
     timeout-minutes: 90
     permissions:
       contents: read
@@ -200,7 +200,7 @@ jobs:
   compare:
     name: Comment on PR
     needs: [prepare, bench]
-    runs-on: ubuntu-24.04
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 10
     if: needs.prepare.outputs.compare == 'true'
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,8 @@ cargo clippy --workspace --lib --examples --tests --benches --all-features --loc
 cargo sort --check --workspace --grouped --order package,workspace,lints,profile,bin,benches,dependencies,dev-dependencies,features
 
 # Benchmarks
-cargo bench -p mega-evm --bench transact
+cargo bench -p mega-evm --bench transact                                    # wall-clock (stdout only)
 cargo codspeed build -p mega-evm --bench <target> && cargo codspeed run   # instruction counts (Linux only)
-# note: criterion's local HTML reports (target/criterion/report) are no longer generated —
-# the criterion dependency is the codspeed-criterion-compat shim without the html_reports feature
 
 # no_std check (run against riscv target)
 cargo check -p mega-evm --target riscv64imac-unknown-none-elf --no-default-features
@@ -297,6 +295,9 @@ When the agent is requested to implement a new feature or bug fix, it should con
 - **Always run benchmarks locally before committing.**
   New or modified benchmarks must be executed locally (`cargo bench -p mega-evm --bench <name>`) to verify they pass before committing.
   Benchmarks may compile but panic at runtime due to missing setup (e.g., required block fields), so compilation alone is not sufficient.
+  Local wall-clock output is stdout-only: the `criterion` dev-dependency is the `codspeed-criterion-compat` shim without the `html_reports` feature, so `target/criterion/report/**` is no longer generated.
+  For instruction-count deltas across a PR, use the CodSpeed report posted on the PR rather than local wall-clock numbers.
+  Escape hatch if distribution plots are needed while investigating a regression: temporarily re-enable `html_reports` (and `plotters`) on the local `criterion` dev-dependency and re-run `cargo bench` — do not commit that change.
 - **Use `test_` prefix for Rust test function names.**
   New `#[test]` functions should be named with a `test_` prefix for consistency with this repository and upstream revm style.
   If editing nearby tests in the same module, align names to the same `test_` style when reasonable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ cargo clippy --workspace --lib --examples --tests --benches --all-features --loc
 cargo sort --check --workspace --grouped --order package,workspace,lints,profile,bin,benches,dependencies,dev-dependencies,features
 
 # Benchmarks
-cargo bench -p mega-evm --bench transact                                    # wall-clock (stdout only)
+cargo bench -p mega-evm --bench transact                                  # wall-clock + HTML report
 cargo codspeed build -p mega-evm --bench <target> && cargo codspeed run   # instruction counts (Linux only)
 
 # no_std check (run against riscv target)
@@ -295,9 +295,7 @@ When the agent is requested to implement a new feature or bug fix, it should con
 - **Always run benchmarks locally before committing.**
   New or modified benchmarks must be executed locally (`cargo bench -p mega-evm --bench <name>`) to verify they pass before committing.
   Benchmarks may compile but panic at runtime due to missing setup (e.g., required block fields), so compilation alone is not sufficient.
-  Local wall-clock output is stdout-only: the `criterion` dev-dependency is the `codspeed-criterion-compat` shim without the `html_reports` feature, so `target/criterion/report/**` is no longer generated.
   For instruction-count deltas across a PR, use the CodSpeed report posted on the PR rather than local wall-clock numbers.
-  Escape hatch if distribution plots are needed while investigating a regression: temporarily re-enable `html_reports` (and `plotters`) on the local `criterion` dev-dependency and re-run `cargo bench` — do not commit that change.
 - **Use `test_` prefix for Rust test function names.**
   New `#[test]` functions should be named with a `test_` prefix for consistency with this repository and upstream revm style.
   If editing nearby tests in the same module, align names to the same `test_` style when reasonable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ cargo sort --check --workspace --grouped --order package,workspace,lints,profile
 
 # Benchmarks
 cargo bench -p mega-evm --bench transact
+cargo codspeed build -p mega-evm --bench <target> && cargo codspeed run   # instruction counts (Linux only)
 
 # no_std check (run against riscv target)
 cargo check -p mega-evm --target riscv64imac-unknown-none-elf --no-default-features
@@ -290,6 +291,7 @@ When the agent is requested to implement a new feature or bug fix, it should con
 - **Add benchmarks for performance-sensitive changes.**
   Changes on the EVM execution hot path must be accompanied by benchmarks.
   This includes new or modified opcode behavior, gas mechanics, system contract interception, resource limit tracking, and block executor pipeline changes.
+  Per-PR instruction-count reports for these benchmarks are produced automatically by the CodSpeed CI workflow.
 - **Always run benchmarks locally before committing.**
   New or modified benchmarks must be executed locally (`cargo bench -p mega-evm --bench <name>`) to verify they pass before committing.
   Benchmarks may compile but panic at runtime due to missing setup (e.g., required block fields), so compilation alone is not sufficient.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ cargo sort --check --workspace --grouped --order package,workspace,lints,profile
 # Benchmarks
 cargo bench -p mega-evm --bench transact
 cargo codspeed build -p mega-evm --bench <target> && cargo codspeed run   # instruction counts (Linux only)
+# note: criterion's local HTML reports (target/criterion/report) are no longer generated —
+# the criterion dependency is the codspeed-criterion-compat shim without the html_reports feature
 
 # no_std check (run against riscv target)
 cargo check -p mega-evm --target riscv64imac-unknown-none-elf --no-default-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -685,6 +685,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,10 +1292,11 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -1388,10 +1404,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
+name = "codspeed"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7083f253260bcb4aaa3b4aa4c52973703dabc1a85c2f193997e2689aafa8a919"
+dependencies = [
+ "anyhow",
+ "cc",
+ "colored",
+ "getrandom 0.4.3",
+ "glob",
+ "libc",
+ "nix",
+ "serde",
+ "serde_json",
+ "statrs",
+]
+
+[[package]]
+name = "codspeed-criterion-compat"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f24251445188c69d50f10179d795424bd71b533b7e3f84fc03f26893b01af0"
+dependencies = [
+ "clap",
+ "codspeed",
+ "codspeed-criterion-compat-walltime",
+ "colored",
+ "regex",
+]
+
+[[package]]
+name = "codspeed-criterion-compat-walltime"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c38205d56e2cb4fe04b708de7f9653a3f1b89edbe3a20b28f21e9e525e9e061"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "codspeed",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "colored"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "console"
@@ -1507,31 +1588,6 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
 
 [[package]]
 name = "criterion-plot"
@@ -2000,6 +2056,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fixed-hash"
@@ -2806,9 +2868,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -2941,7 +3003,7 @@ dependencies = [
  "alloy-sol-types",
  "auto_impl",
  "bitflags",
- "criterion",
+ "codspeed-criterion-compat",
  "delegate",
  "derive_more",
  "hex",
@@ -3086,6 +3148,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -3743,34 +3817,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
 ]
 
 [[package]]
@@ -5063,9 +5109,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -5191,6 +5237,16 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "statrs"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a3fe7c28c6512e766b0874335db33c94ad7b8f9054228ae1c2abd47ce7d335e"
+dependencies = [
+ "approx",
+ "num-traits",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
+ "plotters",
  "regex",
  "serde",
  "serde_derive",
@@ -3817,6 +3818,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e19e6491bdde87c2c43d70f4c194bc8a758f2eb732df00f61e43f7362e3b4cc"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,6 @@ op-alloy-rpc-types = { version = "0.18.12", default-features = false }
 auto_impl = { version = "1.3", default-features = false }
 bitflags = { version = "2.6", default-features = false }
 clap = { version = "4", default-features = false, features = ["derive"] }
-criterion = { version = "0.5", default-features = false }
 delegate = { version = "0.13", default-features = false }
 derive_more = { version = "2", default-features = false }
 dirs = { version = "6", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -213,18 +213,6 @@ strip = "symbols"
 panic = "unwind"
 codegen-units = 16
 
-# Bench builds must be layout-STABLE, not just fast: with release's 16
-# codegen units + thin LTO, any code change reshuffles function layout
-# binary-wide, and a paired A/B across two builds then measures the
-# reshuffle — a semantically-inert change can read as a multi-percent
-# "significant" delta, including on benches that never execute the changed
-# code. One codegen unit makes intra-crate code placement deterministic
-# given the same source; the bench workflow adds 64-byte function alignment
-# on top. Slower to compile — benches build once per CI side, so the cost
-# is minutes.
-[profile.bench]
-codegen-units = 1
-
 # Use the `--profile profiling` flag to show symbols in release mode.
 # e.g. `cargo build --profile profiling`
 [profile.profiling]

--- a/crates/mega-evm/Cargo.toml
+++ b/crates/mega-evm/Cargo.toml
@@ -47,7 +47,7 @@ tracing.workspace = true
 # `use criterion::...` in the benches is unchanged. Under a normal `cargo bench`
 # it behaves exactly like criterion; under `cargo codspeed` it runs each bench
 # once under valgrind and reports layout-insensitive instruction counts.
-criterion = { package = "codspeed-criterion-compat", version = "5.0.1", default-features = false, features = ["cargo_bench_support"] }
+criterion = { package = "codspeed-criterion-compat", version = "5.0.1", default-features = false, features = ["cargo_bench_support", "html_reports", "plotters"] }
 hex.workspace = true
 mega-evm = { path = ".", features = ["test-utils"] }
 op-revm-latest = { package = "op-revm", version = "20.0.0", default-features = false, features = ["dev", "serde", "std"] }

--- a/crates/mega-evm/Cargo.toml
+++ b/crates/mega-evm/Cargo.toml
@@ -43,7 +43,11 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-criterion = { workspace = true, features = ["html_reports", "plotters", "cargo_bench_support"] }
+# CodSpeed drop-in: `codspeed-criterion-compat` re-exports criterion's API, so
+# `use criterion::...` in the benches is unchanged. Under a normal `cargo bench`
+# it behaves exactly like criterion; under `cargo codspeed` it runs each bench
+# once under valgrind and reports layout-insensitive instruction counts.
+criterion = { package = "codspeed-criterion-compat", version = "5.0.1", default-features = false, features = ["cargo_bench_support"] }
 hex.workspace = true
 mega-evm = { path = ".", features = ["test-utils"] }
 op-revm-latest = { package = "op-revm", version = "20.0.0", default-features = false, features = ["dev", "serde", "std"] }


### PR DESCRIPTION
## Summary

- Adopt CodSpeed simulation mode as the per-PR performance verdict: retired-instruction counts are layout-insensitive, so they can resolve changes that the wall-clock A/B harness buries under the multi-percent relink/layout noise floor measured in #335.
- Swap the `criterion` dev-dependency to `codspeed-criterion-compat` 5.0.1 — a package rename only: bench sources are unchanged, plain `cargo bench` keeps the wall-clock path, and the `html_reports`/`plotters` features are preserved so local HTML reports under `target/criterion` keep working.
- Add `.github/workflows/codspeed.yml`: one job per bench target (7-target matrix) running `cargo codspeed` under valgrind on PRs (path-filtered to changes that can move instruction counts), pushes to main, and manual dispatch. Informational only — not a required check. `cargo-codspeed` installs as a prebuilt binary and the matrix legs share one build cache.
- Revert the disproven binary-layout stabilization: `[profile.bench] codegen-units = 1` (workspace `Cargo.toml`) and `-C llvm-args=-align-all-functions=6` (benchmark workflow). Two probe rounds in #335 showed it ineffective (9 → 16 spurious significant lanes, worst +8.4%), with CGU=1 a suspected net negative. The bench workflow keeps its explicit opt-out of the setup action's default `-D warnings` (measurement builds should not fail on unrelated warnings), and the codspeed workflow opts out for the same reason.
- Document the local instruction-count repro command in `AGENTS.md`.

## Verification

- Wall-clock path unchanged with the compat dep: `cargo bench -p mega-evm --bench mega_bench -- 'rex4/sload_100' --sample-size 10` runs green and `target/criterion/**` — including the HTML report and distribution plots — is written as before, so both `/benchmark` (stdout) and downstream estimate consumers are unaffected.
- `cargo fmt` / `clippy` / `cargo sort` / riscv64 `no_std` check all green (the new dependency is dev-only).
- The exact build/run invocation was validated end-to-end on a fork dry-run, and the workflow has since produced real reports on this PR: CodSpeed detected all 306 benchmarks and posts the per-PR instruction-count comment.

## Notes

- The CodSpeed GitHub App is installed and uploads work (OIDC, no token secret). The install wizard auto-opened #338, which duplicates this onboarding with a slimmer setup; it can be closed in favor of this PR.
- Timing from the first full runs: a cold matrix leg finishes in ~12 minutes and a warm one in 2–7 minutes, so none of the heavy targets (`block_bench`, `attack_replay`, `ctt`) needs to be dropped. The per-target timeout is set to 30 minutes accordingly.
