### PR TITLE
docs(block): correct deposit DA-size tracking comment

### DIFF
--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -107,8 +107,9 @@
 //!   block-level Data Availability size limit checks during pre-execution validation
 //! - **Rationale**: Deposit transactions are trustless L1→L2 messages that cannot be censored. They
 //!   must be included in blocks regardless of their DA size to maintain bridge integrity
-//! - **Tracking**: While exempt from limit checks, deposit DA sizes are still tracked and
-//!   accumulated in block DA usage counters for monitoring purposes
+//! - **Tracking**: Deposit DA sizes are not accumulated into the block DA usage counter
+//!   (`block_da_size_used`). The spec permits tracking them for monitoring (RFC-2119 MAY), but the
+//!   executor opts out, so the counter reflects only non-deposit transactions.
 //! - **Other Limits**: Deposit transactions are still subject to all other limits (gas, tx size,
 //!   compute gas, data size, KV updates)
 //!


### PR DESCRIPTION
## Summary

The `block::limit` module doc states that deposit DA sizes are "still tracked and accumulated in block DA usage counters for monitoring purposes." The implementation does the opposite: `post_execution_update_raw` guards the accumulation with `if !is_deposit`, so `block_da_size_used` only counts non-deposit transactions (its own unit test, `test_post_execution_update_raw_skips_da_for_deposits`, asserts this).

The spec treats this tracking as optional (`resource-limits.md`: DA size "MAY still be tracked for monitoring"), so the executor opting out is fine. This just corrects the comment so it matches the code and spec, and doesn't mislead anyone relying on `block_da_size_used` to reflect the block's full DA weight.

No behavior change (comment only).