### PR TITLE
fix(rex6): review-driven fixes + remaining hardening (follow-up to #348)

### DIFF
--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -786,11 +786,16 @@ where
                     (address, storage_gas)
                 }
             };
-            initial_and_floor_gas.initial_gas += storage_gas.ok_or_else(|| {
-                let err_str =
-                    format!("Failed to get storage gas for callee address: {callee_address}",);
-                Self::Error::from_string(err_str)
-            })?;
+            // Saturating: `storage_gas` is SALT-priced and can saturate to `u64::MAX` under a
+            // full bucket; a plain add could wrap `initial_gas` in release and slip an
+            // intrinsically unaffordable tx past the gas-limit check below. Matches the
+            // authority fold and the unconditional `saturating_mul` in the SALT formula itself.
+            initial_and_floor_gas.initial_gas =
+                initial_and_floor_gas.initial_gas.saturating_add(storage_gas.ok_or_else(|| {
+                    let err_str =
+                        format!("Failed to get storage gas for callee address: {callee_address}",);
+                    Self::Error::from_string(err_str)
+                })?);
 
             // REX6: dynamic SALT account-creation gas for each net-new EIP-7702 authority,
             // folded into initial_gas so it is enforced against gas_limit / fee affordability.
@@ -856,7 +861,9 @@ where
                                     );
                                     Self::Error::from_string(err_str)
                                 })?;
-                            initial_and_floor_gas.initial_gas += storage_gas;
+                            // Saturating for the same reason as the callee/authority folds.
+                            initial_and_floor_gas.initial_gas =
+                                initial_and_floor_gas.initial_gas.saturating_add(storage_gas);
                         }
                         ctx.additional_limit.borrow_mut().record_deposit_caller_creation();
                     }

--- a/crates/mega-evm/src/evm/execution.rs
+++ b/crates/mega-evm/src/evm/execution.rs
@@ -802,7 +802,12 @@ where
                             "Failed to get storage gas for EIP-7702 authority: {authority}",
                         ))
                     })?;
-                initial_and_floor_gas.initial_gas += authority_storage_gas;
+                // Saturating: a heavy-SALT authority can price near `u64::MAX`; a plain add
+                // could wrap `initial_gas` in release builds and let an intrinsically
+                // unaffordable authorization list pass the gas-limit / affordability checks
+                // below. Saturation keeps the total huge so those checks reject it.
+                initial_and_floor_gas.initial_gas =
+                    initial_and_floor_gas.initial_gas.saturating_add(authority_storage_gas);
             }
 
             // REX5+: charge dynamic new-account storage gas for a deposit-driven caller
@@ -825,8 +830,12 @@ where
                 let caller = ctx.tx().caller();
                 let system_address = ctx.system_address;
                 if is_deposit_like_transaction(&ctx.inner.tx, system_address) {
-                    let caller_is_empty =
-                        ctx.journal_mut().inspect_account(caller, false)?.info.is_empty();
+                    // Non-hydrating read: only balance/emptiness are needed, and a caller
+                    // already resident with lazy contract code (e.g. an EIP-7702 delegated
+                    // EOA touched earlier in validation) must not force its bytecode into a
+                    // stateless witness.
+                    let (_, caller_is_empty) =
+                        crate::inspect_account_balance_and_emptiness(ctx.journal_mut(), caller)?;
                     if caller_is_empty {
                         // Self-call corner: if the deposit is a `TxKind::Call(caller)` with
                         // non-zero `value` AND the same empty caller as callee, the existing

--- a/crates/mega-evm/src/system/tx.rs
+++ b/crates/mega-evm/src/system/tx.rs
@@ -122,16 +122,20 @@ pub fn is_deposit_like_transaction(tx: &MegaTransaction, system_address: Address
 /// The exemption is evaluated in `MegaContext::on_new_tx`, which runs *after* `before_run` has
 /// already deposit-promoted a mega system tx (stamping [`MEGA_SYSTEM_TRANSACTION_SOURCE_HASH`] and
 /// flipping `tx_type()` to a deposit). The source-hash branch below therefore carries the match for
-/// promoted txs; the `is_mega_system_transaction_with` branch covers the pre-promotion shape for
-/// any other caller. Both the source hash and the system-address+whitelist gate are protocol-set,
-/// so a user deposit (different source hash, non-system caller) is never matched — unlike
-/// [`is_deposit_like_transaction`].
+/// promoted txs and additionally requires the system caller (the sentinel alone is not trusted —
+/// replay / t8n inputs can arrive already deposit-typed with an arbitrary source hash); the
+/// `is_mega_system_transaction_with` branch covers the pre-promotion shape. A user deposit
+/// (non-system caller) is therefore never matched — unlike [`is_deposit_like_transaction`].
 pub fn is_system_originated(tx: &MegaTransaction, system_address: Address) -> bool {
     // Internal pre-block system calls (EIP-2935 / EIP-4788 / SequencerRegistry) use `0xff..fe` and
     // run via `run_system_call`, so they are never deposit-promoted.
     tx.caller() == alloy_eips::eip4788::SYSTEM_ADDRESS ||
-        // A mega system tx that `before_run` has already promoted to a deposit.
-        tx.deposit.source_hash == MEGA_SYSTEM_TRANSACTION_SOURCE_HASH ||
+        // A mega system tx that `before_run` has already promoted to a deposit. The sentinel
+        // alone is not trusted: replay / t8n inputs can arrive already deposit-typed with an
+        // arbitrary source hash, so require the system caller that every legitimate
+        // promotion carries.
+        (tx.deposit.source_hash == MEGA_SYSTEM_TRANSACTION_SOURCE_HASH &&
+            tx.caller() == system_address) ||
         // A mega system tx in its original (pre-promotion) legacy shape.
         is_mega_system_transaction_with(tx, system_address)
 }
@@ -190,6 +194,17 @@ mod tests {
             "the legacy-typed check no longer matches after promotion",
         );
         assert!(is_system_originated(&tx, MEGA_SYSTEM_ADDRESS), "but the source-hash branch does");
+    }
+
+    #[test]
+    fn test_is_system_originated_rejects_sentinel_hash_with_non_system_caller() {
+        // Anti-bypass: the promotion sentinel can be forged in replay / t8n inputs that accept
+        // deposit fields directly. Without the system caller it must NOT grant the metering
+        // exemption.
+        let mut tx = legacy_call_tx(USER, ORACLE_CONTRACT_ADDRESS);
+        tx.deposit.source_hash = MEGA_SYSTEM_TRANSACTION_SOURCE_HASH;
+        assert_eq!(tx.tx_type(), DEPOSIT_TRANSACTION_TYPE);
+        assert!(!is_system_originated(&tx, MEGA_SYSTEM_ADDRESS));
     }
 
     #[test]

--- a/crates/mega-evm/tests/rex6/eip7702_authority_accounting.rs
+++ b/crates/mega-evm/tests/rex6/eip7702_authority_accounting.rs
@@ -25,6 +25,7 @@ use revm::{
         BlockEnv, TxEnv,
     },
     handler::EvmTr,
+    primitives::TxKind,
 };
 
 // ============================================================================
@@ -1024,6 +1025,29 @@ fn test_rex6_authority_scan_skipped_when_pre_frame_limit_latched() {
         "must halt on the data-size limit: {:?}",
         r.result
     );
+}
+
+/// A top-level `CREATE` whose deploy address falls in a saturated SALT bucket must be rejected at
+/// validation (the SALT-priced creation gas saturates toward `u64::MAX` and is folded into
+/// `initial_gas`), not wrap `initial_gas` and execute underpaid. Guards the callee/create SALT
+/// fold that is a sibling of the authority fold.
+#[test]
+fn test_rex6_saturated_create_salt_gas_rejects_instead_of_wrapping() {
+    let mut db =
+        MemoryDatabase::default().account_balance(CALLER, U256::from(1_000_000_000_000_000_000u64));
+    // The top-level CREATE from CALLER (nonce 0) deploys to this address; saturate its bucket.
+    let created = CALLER.create(0);
+    let bucket = SimpleBucketHasher::bucket_id(created.as_slice());
+    let envs: Envs = TestExternalEnvs::new().with_bucket_capacity(bucket, u64::MAX);
+
+    let create_tx = TxEnvBuilder::default()
+        .caller(CALLER)
+        .kind(TxKind::Create)
+        .gas_limit(10_000_000)
+        .data(Bytes::from_static(&[0x00])) // STOP initcode
+        .build_fill();
+    let r = try_transact(MegaSpecId::REX6, &mut db, &envs, create_tx);
+    assert!(r.is_err(), "a saturated CREATE SALT price must fail validation, not execute: {r:?}",);
 }
 
 /// A net-new authority priced in a saturated SALT bucket must be rejected at validation

--- a/crates/mega-evm/tests/rex6/eip7702_authority_accounting.rs
+++ b/crates/mega-evm/tests/rex6/eip7702_authority_accounting.rs
@@ -1025,3 +1025,24 @@ fn test_rex6_authority_scan_skipped_when_pre_frame_limit_latched() {
         r.result
     );
 }
+
+/// A net-new authority priced in a saturated SALT bucket must be rejected at validation
+/// (`initial_gas` folds the authority's dynamic account-creation gas, which here saturates
+/// toward `u64::MAX`), not wrap `initial_gas` around and execute with too little prepaid gas.
+#[test]
+fn test_rex6_saturated_authority_salt_gas_rejects_instead_of_wrapping() {
+    let mut db = funded_db();
+    let bucket = SimpleBucketHasher::bucket_id(AUTHORITY_A.as_slice());
+    let envs: Envs = TestExternalEnvs::new().with_bucket_capacity(bucket, u64::MAX);
+
+    let r = try_transact(
+        MegaSpecId::REX6,
+        &mut db,
+        &envs,
+        tx_with_auths(vec![auth(AUTHORITY_A, 0, 0)]),
+    );
+    assert!(
+        r.is_err(),
+        "a saturated authority SALT price must fail validation, not execute: {r:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #348 (the faithful REX6 migration). Collects the review-driven fixes and the remaining REX6 hardening so the migration PR itself stays a clean, byte-faithful merge. **Base is the migration branch** (`cz/feat/rex6-preview`); retarget to `main` once #348 merges. All changes are REX6-only (unstable spec) or replay-safe hardening of frozen paths — no live-spec behavior changes.

## Fixes already applied (each pinned by a regression test)

- **Witness / stateless friendliness:** deposit-style transactions skip the fee-recipient snapshots; fee-recipient and deposit-caller reads use a non-hydrating balance/emptiness helper; the EIP-7702 authority scan short-circuits once a pre-frame limit is latched.
- **Arithmetic on attacker-influenced values:** the EIP-7702 authority, callee/create, and deposit-caller SALT-gas folds all saturate into `initial_gas`, so an intrinsically unaffordable transaction is rejected instead of wrapping past the gas-limit check.
- **Forgeable-input trust:** the system-tx metering exemption requires the promotion sentinel to be paired with the system caller.
- **Docs / hygiene:** mega-evme CLI docs synced to the Rex6 default; stale helper/metering-path comments corrected; spec-gate boundary tests added (killing the mutation-gate survivors); pop-frame cache invariant pinned with debug asserts.

## Remaining work (found in the pre-push adversarial sweep; not yet fixed)

- **Caller-only system exemption:** `is_system_originated`'s first branch grants the exemption on `caller == 0xffff…fffe` alone; a replay / t8n / direct `transact_raw` input can set that caller without entering through `run_system_call`. Needs the exemption gated on the real system-call entry, not the caller address alone.
- **Authority accounts loaded before caller validation:** the REX6 authority scan in `validate()` reads each authority account (and its code) before `pre_execution` validates the caller's nonce / funds / code and the final Mega-gas bound; an otherwise-doomed type-4 tx still requests those accounts, which a minimal stateless witness cannot satisfy.
- **CALL delegation-code witness dependency** (flagged in passing during the sweep) — to be confirmed and scoped.
- Previously-ticketed REX6 lifecycle items carried from the preparation line: CREATE pre-frame accounting lifecycle; post-execution fee-reward accounting vs limit latching; source-side SELFDESTRUCT beneficiary-detention marking when volatile access is enabled and the beneficiary is a CREATE-predicted address.
