### PR TITLE
docs: add mega-evm review checks to REVIEW.md

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -36,7 +36,7 @@ This is the single most important correctness concern in mega-evm.
 - New workspace dependencies should use `default-features = false` — features are opted-in explicitly.
 - **Release-blocking dependencies.**
   A crate that gets published must not depend on an unpublished crate.
-  `cargo publish -p <crate> --locked` has to resolve at release time.
+  `cargo publish -p <crate> --locked --dry-run` has to resolve at release time.
   Flag a new dependency that would break the next release's resolution.
 
 ## Tests
@@ -50,9 +50,10 @@ This is the single most important correctness concern in mega-evm.
   These tests should not be hand-edited otherwise — see `crates/mega-evm/tests/mutation/main.rs`.
 - **Benchmark methodology.**
   A perf-comparison PR must pin comparable hardforks on both arms.
-  A hard-coded `OpSpecId` that ignores the enum default silently benches the wrong fork.
-  Use an even round count.
-  Odd defeats A/B alternation.
+  Missing the required explicit hardfork pin can silently bench the wrong fork when a shared bench subject defaults to a different one.
+  For the paired Criterion-style harness, use an even round count.
+  Odd defeats A/B alternation there.
+  Do not apply that even-round rule to the replay ABBA harness.
   Adjudicate quantitatively.
   Don't drop a `saturating_sub`/guard "for speed" without a measured, attributable gain.
 - **Storage-layout parity.**

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -34,6 +34,7 @@ This is the single most important correctness concern in mega-evm.
 - `no_std` compatibility must be maintained in the `mega-evm` crate — no direct `std::` usage.
   Follow the existing pattern: `#[cfg(not(feature = "std"))] use alloc as std;`.
 - New workspace dependencies should use `default-features = false` — features are opted-in explicitly.
+- **Release-blocking dependencies.** A crate that gets published must not depend on an unpublished crate; `cargo publish -p <crate> --locked` has to resolve at release time. Flag a new dependency that would break the next release's resolution.
 
 ## Tests
 
@@ -44,6 +45,8 @@ This is the single most important correctness concern in mega-evm.
   Their comments — especially the `file:line:col` mutation-location references — must be kept up to date when the referenced source moves.
   Flag any PR that shifts lines in a mutated source file but leaves a now-stale location reference (or an orphaned/renamed test) in `tests/mutation/`; a reference that no longer points at its mutant defeats the purpose of the linkage.
   These tests should not be hand-edited otherwise — see `crates/mega-evm/tests/mutation/main.rs`.
+- **Benchmark methodology.** A perf-comparison PR must pin comparable hardforks on both arms (a hard-coded `OpSpecId` that ignores the enum default silently benches the wrong fork), use an even round count (odd defeats A/B alternation), and adjudicate quantitatively. Don't drop a `saturating_sub`/guard "for speed" without a measured, attributable gain.
+- **Storage-layout parity.** Where Rust mirrors a Solidity storage layout, add a parity test against that layout so a field reordering fails a test instead of drifting silently into a consensus bug.
 
 ## mega-evm tooling and scope
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -34,7 +34,10 @@ This is the single most important correctness concern in mega-evm.
 - `no_std` compatibility must be maintained in the `mega-evm` crate — no direct `std::` usage.
   Follow the existing pattern: `#[cfg(not(feature = "std"))] use alloc as std;`.
 - New workspace dependencies should use `default-features = false` — features are opted-in explicitly.
-- **Release-blocking dependencies.** A crate that gets published must not depend on an unpublished crate; `cargo publish -p <crate> --locked` has to resolve at release time. Flag a new dependency that would break the next release's resolution.
+- **Release-blocking dependencies.**
+  A crate that gets published must not depend on an unpublished crate.
+  `cargo publish -p <crate> --locked` has to resolve at release time.
+  Flag a new dependency that would break the next release's resolution.
 
 ## Tests
 
@@ -45,8 +48,16 @@ This is the single most important correctness concern in mega-evm.
   Their comments — especially the `file:line:col` mutation-location references — must be kept up to date when the referenced source moves.
   Flag any PR that shifts lines in a mutated source file but leaves a now-stale location reference (or an orphaned/renamed test) in `tests/mutation/`; a reference that no longer points at its mutant defeats the purpose of the linkage.
   These tests should not be hand-edited otherwise — see `crates/mega-evm/tests/mutation/main.rs`.
-- **Benchmark methodology.** A perf-comparison PR must pin comparable hardforks on both arms (a hard-coded `OpSpecId` that ignores the enum default silently benches the wrong fork), use an even round count (odd defeats A/B alternation), and adjudicate quantitatively. Don't drop a `saturating_sub`/guard "for speed" without a measured, attributable gain.
-- **Storage-layout parity.** Where Rust mirrors a Solidity storage layout, add a parity test against that layout so a field reordering fails a test instead of drifting silently into a consensus bug.
+- **Benchmark methodology.**
+  A perf-comparison PR must pin comparable hardforks on both arms.
+  A hard-coded `OpSpecId` that ignores the enum default silently benches the wrong fork.
+  Use an even round count.
+  Odd defeats A/B alternation.
+  Adjudicate quantitatively.
+  Don't drop a `saturating_sub`/guard "for speed" without a measured, attributable gain.
+- **Storage-layout parity.**
+  Where Rust mirrors a Solidity storage layout, add a parity test against that layout.
+  A field reordering should fail a test instead of drifting silently into a consensus bug.
 
 ## mega-evm tooling and scope
 


### PR DESCRIPTION
Supplements the baseline rubric with mega-evm-specific checks it doesn't cover:

- Release-blocking dependencies (`cargo publish -p <crate> --locked` must resolve at release time).
- Benchmark methodology (comparable hardforks on both arms, even round counts, quantitative adjudication).
- Storage-layout parity test against the Solidity layout so a field reorder fails a test.

Additive only — no existing rules changed.
