### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evm"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "mega-evme"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "mega-state-test"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -3052,7 +3052,7 @@ dependencies = [
 
 [[package]]
 name = "mega-system-contracts"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "mega-t8n"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "alloy-consensus",
  "alloy-primitives",
@@ -5218,7 +5218,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "state-test"
-version = "1.6.1"
+version = "1.7.0"
 dependencies = [
  "clap",
  "mega-evm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ exclude = []
 # https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html
 resolver = "2"
 [workspace.package]
-version = "1.6.1"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.91"
 license = "MIT OR Apache-2.0"
@@ -122,9 +122,9 @@ too_long_first_doc_paragraph = "allow"
 
 [workspace.dependencies]
 # megaeth
-mega-evm = { path = "./crates/mega-evm", version = "1.6.1", default-features = false }
-mega-state-test = { path = "./crates/mega-state-test", version = "1.6.1", default-features = false }
-mega-system-contracts = { path = "./crates/system-contracts", version = "1.6.1", default-features = false }
+mega-evm = { path = "./crates/mega-evm", version = "1.7.0", default-features = false }
+mega-state-test = { path = "./crates/mega-state-test", version = "1.7.0", default-features = false }
+mega-system-contracts = { path = "./crates/system-contracts", version = "1.7.0", default-features = false }
 
 # revm
 op-revm = { version = "8.1.0", default-features = false }


### PR DESCRIPTION
## Summary

Bump the workspace version from 1.6.1 to 1.7.0 in preparation for the v1.7.0 tag and release.

- Bump `[workspace.package].version` and the three internal path-dependency versions (`mega-evm`, `mega-state-test`, `mega-system-contracts`) in `Cargo.toml` in lockstep.
- Regenerate `Cargo.lock` accordingly.