### PR TITLE
docs: add audit-derived execution and dev-tool rules to REVIEW.md

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -25,8 +25,18 @@ This is the single most important correctness concern in mega-evm.
 - Pre-block helpers (system contract deploys, pre-exec system calls, etc.) must return `Option<EvmState>` for the block executor to commit — never call `db.commit(...)` directly.
   Even idempotent "no change" paths must return `Some(EvmState)` with a read-only account entry; silently returning `None` drops the account from the stateless witness read set and produces an incomplete proof.
   See `crates/mega-evm/src/system/AGENTS.md` → `PRE-BLOCK STATE CHANGE CONTRACT`.
+  The same applies inside execution: read through the journal (`inspect_account`), never `journal.database.basic(...)`, or the account driving the result is missing from the returned state — and an early halt placed before the sandbox state merge drops that read set entirely.
 - Per-frame gas mechanisms (stipends, adjustments) must handle all frame termination paths: system contract interception, gas rescue on limit exceed, and frame return.
   Missing any path causes gas leakage.
+- **Metering must be symmetric across every exit path of the instruction it wraps, and must not double-count.**
+  A `record_*` / `compute_gas!` sitting on the success arm, or after the inner revm instruction returns, is skipped by stack underflow, OOG, decode failure and inner-call failure; conversely, charge per applied action rather than per candidate, and dedup across every frame shape (top-level, `caller == target` self-transfer, repeated recipients).
+- **Ordering: guards before work, enforcement before mutation.**
+  `inspect_account` / `resize_memory!` / `keccak256` / storage-gas computation belong after the wrapped instruction's own validity checks (salt underflow, EIP-3860 size, EIP-214 static, empty initcode), and a limit must be enforced before the state change it guards — a latched flag surfacing as a `Halt` after `pre_execution` journaled the writes leaves them committed under a failed receipt.
+- **Keyless / sandbox child execution must reconcile every effect dimension into the parent and block:** gas, each limit dimension, volatile access, logs and the read set.
+  A `SandboxOutcome` carrying state but dropping logs, or a tracker allocated fresh instead of merged, is a consensus bug; and a value validated before execution (a gas-limit override) must not be mutated afterwards.
+- **The volatile-access / beneficiary-detention boundary must cover every sensitive surface** — a new volatile-derived read or side effect (Oracle SLOAD or hint, SELFDESTRUCT beneficiary, EIP-7702 delegate) has to consult the tracker; resolve the delegate before marking, and check the destructing contract itself, not only the stack target.
+- **System calls and system-address transactions:** a mandatory pre-block system call with dynamic cost needs a `block.gas_limit`-derived budget, not revm's fixed default, or a spec flipping it fail-closed rejects blocks persistently; a system-address transaction must validate nonce, chain-id and EIP-3607 against replay, and a commit step re-checking block limits must re-check the nonce too.
+- **Hot-path accounting must stay O(1)** in attacker-controlled call depth and authorization count — no frame-stack walk per opcode, no unindexed `Vec` scan per authorization.
 
 ## Design and architecture
 
@@ -59,6 +69,20 @@ This is the single most important correctness concern in mega-evm.
 - **Storage-layout parity.**
   Where Rust mirrors a Solidity storage layout, add a parity test against that layout.
   A field reordering should fail a test instead of drifting silently into a consensus bug.
+  Generated artifacts need the same treatment: embedded bytecode and slot constants must be cross-checked against the Solidity source at build time (not merely self-hashed), `build.rs` must list the generated sources in `rerun-if-changed`, and a test asserting a constant against itself is tautological.
+- **Would this test still pass if the behavior it claims to check regressed?**
+  The fixture runners have failed this repeatedly: an exception assertion accepting any `Err`, a setup failure skipping execution, a `zip` letting missing output pass, a duplicate test name silently overwriting, an `unwrap_or(default)` rewriting a contradictory fixture into a valid one, a filename-based skip, an unconditional prune before state-root validation.
+  Benchmarks fail it the same way — an unfunded inner call, zero-byte initcode, a discarded inner-call result or an undeployed address means the measured path never runs, and a mock database that cannot fail a lookup cannot test its error path.
+
+## Dev tools and test infrastructure
+
+Applies to `bin/mega-evme`, `bin/mega-t8n`, `crates/mega-state-test`, `crates/state-test`, test utilities and benches — not consensus code, but `mega-state-test` is a published library and tool output feeds fixtures and indexers. Default severity cap `[Minor]`; raise only when the defect reaches that published API or corrupts a downstream fixture.
+
+- An input-handling path (fixture, CLI flag, file path, RPC response) must fail with a structured error instead of aborting the process: a panic, unchecked index or overflow on **untrusted** input is the defect, as is `process::exit` from a library path — an idiomatic `unwrap` on a known-good value is not. A batch loop records a per-item rejection rather than aborting and dropping the rest.
+- A computed output field — state root, receipt field, contract address, log index, provenance — must carry its real value or an explicit error; substituting a zero, `None`, `default()` or a silently clamped bound reports success for a result the tool never computed. Serialized output must be deterministically ordered, and an advertised flag must not be a stub returning `Ok(())`.
+- Replay and capture must not diverge from real execution — source env values from the block header, honor tracer/reduction flags, key a fork cache by endpoint and not just chain id, never let a cached fixture shadow live RPC.
+- Output hygiene: escape untrusted strings (revert reasons, paths, RPC payloads) before a terminal sees them, never format a secret key or credential-bearing URL into an error or log, and contain output paths — `PathBuf::join` on an external filename escapes the base directory.
+- An override that mutates a `TxEnv` still needs `validate()`; `entry(addr).or_default()` shadows real forked account metadata; a shared thread-local cannot carry per-transaction override data.
 
 ## mega-evm tooling and scope
 


### PR DESCRIPTION
## Summary

`REVIEW.md` supplements the centralized `pr-review` baseline with rules specific to mega-evm. This adds the rules that 125 confirmed true-positive findings (GuardianAudits main / remediations / round 2, and V12 — tracked in `megaeth-labs/mega-audits`) generalize into.

Purely additive: no existing rule is reworded or removed. The existing `Per-frame gas mechanisms …` bullet is untouched.

**Consensus-critical execution** — 6 new bullets, and one sentence appended to the pre-block-helper bullet:

| Rule | Findings | n |
|---|---|---|
| Metering symmetric across every exit path, and no double-count | `ME-GR-20260521-012/013`, `ME-V12-20260609-079/081/111/112`, `ME-G2-20260703-001`, `ME-GR-20260521-009`, `ME-V12-20260609-083` | 9 |
| Ordering: guards before work, enforcement before mutation | `ME-GR-20260521-003/007/010`, `ME-G2-20260703-002/010` | 5 |
| Keyless / sandbox reconciles every effect dimension | `ME-GM-20260520-009`, `ME-GR-20260521-008/014/015/016` | 5 |
| volatile-access / beneficiary-detention boundary coverage | `ME-G2-20260703-009`, `ME-V12-20260609-041/076` | 3 |
| System calls and system-address transactions | `ME-GR-20260521-004/005`, `ME-V12-20260609-002/037/071` | 5 |
| Hot-path accounting stays O(1) | `ME-GR-20260521-006/011`, `ME-V12-20260609-075` | 3 |
| Witness read-set completeness (appended to existing bullet) | `ME-G2-20260703-003/006` | 2 |

**Tests** — storage-layout parity extended to generated artifacts (`ME-V12-20260609-007/008/009/057`), plus one new test-discrimination rule distilled from 14 findings where a fixture runner or bench produced a false green.

**New `## Dev tools and test infrastructure` section** — 5 rules over 54 findings, covering `bin/mega-evme`, `bin/mega-t8n`, `crates/mega-state-test`, `crates/state-test`, test utilities and benches. The section carries an explicit `[Minor]` severity cap, raised only when a defect reaches the published `mega-state-test` API or corrupts a downstream fixture — this encodes the team's existing deprioritization of this backlog rather than letting tooling nits compete with consensus findings.

Deliberately excluded so this file does not restate the inlined baseline: 9 unbounded tool-input findings (baseline "apply size checks before accumulating bytes", and all are self-inflicted where operator == attacker), plus 11 findings rejected as non-generalizable (frozen-spec one-offs, cosmetic, by-design, latent-only, test-only). Finding ids live here rather than in `REVIEW.md` — the file is a rulebook, and the ids only resolve in the tracker.

## Test plan

Docs only; no code, test or CI change. Verified before opening:

- `markdownlint-cli2` and `prettier --check` both pass.
- Every crate/binary path in an added line exists on `main`, and the published/unpublished split is correct: `crates/mega-state-test` is the published runner library, `crates/state-test` is `publish = false`.
- Every referenced identifier exists and its claim matches the source: `inspect_account` vs `journal.database.basic(...)`, `SandboxOutcome`, `compute_gas!`, `resize_memory!`, `pre_execution`, `TxEnv::validate()`, `entry(addr).or_default()`, `build.rs` `rerun-if-changed`, `PathBuf::join`.
- Every EIP number checked against the mechanism it is cited for: EIP-3860 (initcode size), EIP-214 (static context), EIP-3607 (sender with deployed code), EIP-7702 (authorization lists), EIP-2935 / EIP-4788 (pre-block system calls).
- Each rule re-checked against its source findings so it does not overstate what they established — e.g. the metering rule is scoped to the Mega compute-gas wrapper (`record_*` / `compute_gas!`), not to EVM gas.
- The two dev-tool input rules are deliberately phrased around behavior rather than a banned-token list, so the review agent does not flag idiomatic `unwrap` in benches or a legitimate `None`/`default()` return.

## Labels checklist

- `spec:unchanged` — no spec behavior, gas cost, opcode or system contract is touched.
- `comp:doc` — repository documentation only. (The template comment lists `comp:misc`, but `comp:doc` exists and fits exactly; happy to switch if `comp:misc` is preferred.)
- `api:unchanged` — no public API change.
