### PR TITLE
ci: run pr-review under the CI app identity

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -67,14 +67,28 @@ jobs:
       id-token: write
       actions: read
     steps:
+      # Review under the CI app identity rather than the job token: it is what
+      # lets the action resolve stale review threads (the shared action gates
+      # --resolve-threads on github_identity_token being non-empty).
+      - uses: actions/create-github-app-token@v3
+        id: app-token
+        with:
+          app-id: ${{ vars.CI_APP_ID }}
+          private-key: ${{ secrets.MEGA_CI_APP_PK }}
+          owner: megaeth-labs
+          repositories: mega-evm
+
       - uses: actions/checkout@v4
         with:
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
           submodules: recursive
           fetch-depth: 1
 
       - uses: megaeth-labs/documentation/.github/actions/claude-pr-review@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_identity_token: ${{ steps.app-token.outputs.token }}
           allowed_bots: "mega-putin"
           extra_prompt: |
             ## Documentation scope exclusion


### PR DESCRIPTION
## Summary

- Mint a CI app token in the `pr-review` job and pass it to the shared action as `github_identity_token`.

The shared `claude-pr-review` action gates review-thread resolution on `github_identity_token` being non-empty (`--resolve-threads "${{ inputs.github_identity_token != '' }}"`). With only the job token, the action publishes reviews and updates the sticky status, but every addressed automated thread stays open — the author fixes the code and the thread never closes.

Also checks out under the app identity with `persist-credentials: false`, matching the pattern already in use in `stateless-validator`.

## Test plan

- The `pr-review` job on this PR mints the token and runs end to end; a failing `app-token` step means the CI app is not installed on this repo or the org secret is not scoped to it.
- Confirm the review publishes, then push a fix for a flagged finding and confirm the thread is resolved rather than left open.