### PR TITLE
ci: point Claude actions at megaeth-labs/.github

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,7 +43,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: megaeth-labs/documentation/.github/actions/claude-interactive@main
+      - uses: megaeth-labs/.github/.github/actions/claude-interactive@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "mega-putin"
@@ -85,7 +85,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: megaeth-labs/documentation/.github/actions/claude-pr-review@main
+      - uses: megaeth-labs/.github/.github/actions/claude-pr-review@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_identity_token: ${{ steps.app-token.outputs.token }}
@@ -183,7 +183,7 @@ jobs:
           submodules: recursive
           fetch-depth: 1
 
-      - uses: megaeth-labs/documentation/.github/actions/claude-label-check@main
+      - uses: megaeth-labs/.github/.github/actions/claude-label-check@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "mega-putin"
@@ -201,7 +201,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: megaeth-labs/documentation/.github/actions/claude-issue-triage@main
+      - uses: megaeth-labs/.github/.github/actions/claude-issue-triage@main
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_bots: "mega-putin"


### PR DESCRIPTION
Repoints this repo's `claude.yml` from `megaeth-labs/documentation/.github/actions/claude-*` to the new org home **`megaeth-labs/.github/.github/actions/claude-*`**, tracking `@main`.

Part of consolidating shared CI into `megaeth-labs/.github` ([.github#4](https://github.com/megaeth-labs/.github/pull/4)). No behavior change — the actions were migrated verbatim. Safe to merge independently; the `documentation` copies remain until all consumers are migrated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)