### PR TITLE
ci: let PR comments trigger a Claude review reconcile round

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,14 +51,17 @@ jobs:
 
   pr-review:
     concurrency:
-      group: claude-pr-review-${{ github.event.pull_request.number }}
+      group: claude-pr-review-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     if: |
-      github.event_name == 'pull_request' &&
-      (github.event.action == 'opened' ||
-       github.event.action == 'synchronize' ||
-       github.event.action == 'ready_for_review' ||
-       github.event.action == 'reopened')
+      (github.event_name == 'pull_request' &&
+       (github.event.action == 'opened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review' ||
+        github.event.action == 'reopened')) ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       github.event.comment.user.login != 'mega-maxwell[bot]')
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -80,6 +83,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
           submodules: recursive


### PR DESCRIPTION
## Summary

Extends the `pr-review` job in `.github/workflows/claude.yml` so a PR comment can trigger a Claude review reconcile round, in addition to the existing push-triggered reviews.

## Changes

Three changes to the `pr-review` job only (the interactive, doc-impact, label-check, and issue-triage jobs are untouched):

- **`issue_comment` trigger**: the `if:` condition now also fires on `issue_comment` events, gated so it only runs on comments attached to a PR (`github.event.issue.pull_request != null`). This leans on the shared `claude-pr-review` action's new `issue_comment` support to reconcile open review questions/findings when someone answers in a PR comment.
- **Non-maxwell guard**: comments from any human or bot are allowed; only the reviewer bot itself, `mega-maxwell[bot]`, is skipped so Claude does not re-trigger on its own review comments.
- **Concurrency fallback**: the concurrency group now falls back to `github.event.issue.number` when `github.event.pull_request.number` is absent (as it is on comment events), keeping one review per PR regardless of trigger.
- **PR-head checkout on comment events**: the `actions/checkout` step now checks out `refs/pull/{issue.number}/head` on `issue_comment` events. Without this the reviewer would read `main` instead of the PR branch, since a comment payload carries no PR ref.

Push-triggered reviews (`opened`/`synchronize`/`ready_for_review`/`reopened`) are unchanged — the existing condition is preserved verbatim, just OR'd with the new branch.

The `on:` block already had `issue_comment: [created]` (used by the interactive @claude job) and was not modified.

Relates to megaeth-labs/.github#8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)