### PR TITLE
docs(evm): standardize spec-gate notation and gas forwarding ratio

### DIFF
--- a/crates/mega-evm/src/evm/host.rs
+++ b/crates/mega-evm/src/evm/host.rs
@@ -375,7 +375,7 @@ impl<DB: Database, ExtEnvs: ExternalEnvTypes> HostExt for MegaContext<DB, ExtEnv
 /// | --- | --- | --- | --- |
 /// | Code / execution target | delegate | revm's `load_account_delegated` (not these primitives) | revm-owned |
 /// | Storage / SALT / state-growth / account-write accounting | original | `inspect_account` | REX5+ original; pre-REX5 followed the delegate (frozen) |
-/// | CALL-family beneficiary / volatile-access check | delegate | `resolve_eip7702_delegate_address` | REX6+ only; `<=` REX5 compares the raw operand (frozen) |
+/// | CALL-family beneficiary / volatile-access check | delegate | `resolve_eip7702_delegate_address` | REX6+ only; pre-REX6 compares the raw operand (frozen) |
 /// | Validate-time authorization accounting | original authority | `inspect_account` with `load_code = true` (EIP-7702 / EIP-3607 detection) | scan-wide |
 ///
 /// `inspect_account_delegated` follows the delegate; it backs the frozen pre-REX5 accounting path

--- a/crates/mega-evm/src/evm/instructions.rs
+++ b/crates/mega-evm/src/evm/instructions.rs
@@ -55,7 +55,7 @@ use revm::{
 /// ## CREATE/CREATE2 Opcodes
 /// - Compute gas: Standard costs (32,000 for CREATE, 6 gas/word for CREATE2 hashing)
 /// - Storage gas: Dynamic bucket-based costs for new account creation
-/// - Gas forwarding: 98/100 rule (2% withheld vs. standard 1.5%)
+/// - Gas forwarding: 98/100 rule (2% withheld vs. standard 1/64 ≈ 1.56% per EIP-150)
 /// - Data/KV tracking: 40 bytes + 1 KV update per account creation
 ///
 /// ## CALL-like Opcode
@@ -66,7 +66,7 @@ use revm::{
 ///   storage-gas-heavy operations such as `LOG`
 /// - REX4+: Compute gas remains capped at the original `forwarded_gas + CALL_STIPEND`, so the extra
 ///   stipend cannot be used for pure computation
-/// - Gas forwarding: 98/100 rule (2% withheld vs. standard 1.5%)
+/// - Gas forwarding: 98/100 rule (2% withheld vs. standard 1/64 ≈ 1.56% per EIP-150)
 /// - Oracle detection: Handled at frame level (in `frame_init`), applies gas detention for both
 ///   direct transaction calls and internal CALL operations
 /// - Data/KV tracking: 40 bytes + 2 KV updates when transferring to empty account


### PR DESCRIPTION
## Summary

Two small documentation fixes in the EVM module:

1. **`host.rs` — EIP-7702 address table**: the spec-gate column uses `<= REX5` while every other row (and the rest of the codebase) spells it `pre-REX5` / `pre-REX4`. Replaced with `pre-REX6` for consistency.

2. **`instructions.rs` — gas forwarding ratio**: the parenthetical compares MegaETH's 98/100 rule against "standard 1.5%". The canonical EVM child-frame cap per EIP-150 is `gas - floor(gas / 64)`, i.e. 1/64 ≈ 1.5625% withheld. Updated both the CREATE/CREATE2 and CALL-like opcode sections.

No behavior change — doc comments only.

## Test plan

Doc-only change; verified with `cargo build -p mega-evm` (no compile errors from doc attributes).