### PR TITLE
docs: publish the Rex6 activation timestamps

### DIFF
--- a/docs/spec/AGENTS.md
+++ b/docs/spec/AGENTS.md
@@ -190,7 +190,8 @@ Documentation placement follows **maturity**, not network status:
 - Wrap unstable spec content in `<details>` blocks with a clear label (e.g., "SpecName (unstable): ...").
 - Unstable content MUST still use normative language within the `<details>` block.
 - Do NOT use `<details>` to mark a frozen-but-unscheduled spec.
-  Its content belongs in main prose like any other frozen spec; network status is conveyed by the upgrade page's activation tabs and the upgrade overview, not by hiding the specification.
+  Its content belongs in main prose like any other frozen spec; network status is conveyed by the upgrade overview's activation tabs, not by hiding the specification.
+  Activation timestamps live in `upgrades/overview.md` alone — an individual upgrade page carries none, so there is one place to edit when a spec is scheduled.
 - **Glossary exception**: glossary entries for unstable-spec terms do not use `<details>` blocks.
   Instead, mark them with inline text (e.g., "_(SpecName, unstable)_") at the start of the definition.
 - **Roster-page exception**: a page whose subject is the spec ladder itself (`overview.md`, `hardfork-spec.md`, `upgrades/overview.md`, and the progression line in `glossary.md`) MUST carry the unstable spec in its progression and its per-spec summary, outside `<details>`.

--- a/docs/spec/hardfork-spec.md
+++ b/docs/spec/hardfork-spec.md
@@ -34,7 +34,7 @@ All specs through REX6 are frozen; REX7 is **unstable** and under active develop
 
 Frozen and activated are separate properties.
 A frozen spec's semantics no longer change, but it takes effect on a network only once that network schedules the corresponding hardfork.
-REX6 is frozen and has no activation timestamp on either mainnet or testnet, so both networks currently execute REX5.
+REX7 is unstable and has no activation timestamp on either mainnet or testnet.
 
 ### Backward Compatibility
 
@@ -134,7 +134,7 @@ _See [Rex5 Network Upgrade](upgrades/rex5.md) for full details._
 
 ### REX6
 
-REX6 is frozen but not yet scheduled on any network.
+REX6 is frozen and scheduled on both networks; see the [upgrade overview](upgrades/overview.md) for activation timestamps.
 
 - **Unified per-opcode gas metering order** — Every storage-affecting opcode charges storage gas before its body and records compute gas exactly once after the body completes; the `CREATE2` memory-expansion gas is folded into that single recording.
 - **Consolidated EIP-7702 authorization accounting** — Per-authorization data-size and KV-update charges are narrowed to applied authorizations, authority state growth resolves during validation, net-new authorities pay dynamic SALT account-creation gas, and an applied authority equal to the block beneficiary triggers beneficiary gas detention.

--- a/docs/spec/overview.md
+++ b/docs/spec/overview.md
@@ -70,7 +70,7 @@ Contracts deployed under a given spec will continue to behave identically, regar
 - **REX3** — Oracle gas cap raised to 20M, SLOAD-based oracle detention, keyless deploy compute gas tracking.
 - **REX4** — Per-call-frame resource budgets, relative gas detention, [storage gas stipend](glossary.md#storage-gas-stipend), MegaAccessControl and MegaLimitControl system contracts.
 - **REX5** — SequencerRegistry system contract, Oracle v2.0.0 with dynamic system address, caller-account update deduplication, storage-gas-stipend separated-allowance model, value-transfer CALL/CALLCODE parent compute-gas attribution, CREATE code-deposit compute-gas atomicity, EIP-2935/EIP-4788 pre-block gas floor with fail-closed block rejection, CREATE2 empty-initcode short-circuit, KeylessDeploy trailing-bytes rejection and empty-code log forwarding.
-- **REX6** — Unified per-opcode gas metering order, consolidated EIP-7702 authorization accounting, CREATE-frame accounting corrections, KeylessDeploy sandbox hardening, post-execution fee-reward accounting, system-originated transaction metering exemption, extended beneficiary detention coverage, and SequencerRegistry v2.0.0 rotation hardening. Frozen, but not yet scheduled on any network.
+- **REX6** — Unified per-opcode gas metering order, consolidated EIP-7702 authorization accounting, CREATE-frame accounting corrections, KeylessDeploy sandbox hardening, post-execution fee-reward accounting, system-originated transaction metering exemption, extended beneficiary detention coverage, and SequencerRegistry v2.0.0 rotation hardening.
 - **REX7** — The **unstable** spec, currently open for development. No behavioral change over REX6 yet.
 
 See [Hardforks and Specs](hardfork-spec.md) for full details.

--- a/docs/spec/upgrades/overview.md
+++ b/docs/spec/upgrades/overview.md
@@ -132,14 +132,13 @@ Per-[call-frame](../glossary.md#call-frame) resource budgets, relative gas deten
 
 {% tabs %}
 {% tab title="Testnet" %}
-Not yet scheduled
+`1786330800` (Aug 10, 2026, 03:00 UTC)
 {% endtab %}
 {% tab title="Mainnet" %}
-Not yet scheduled
+`1787626800` (Aug 25, 2026, 03:00 UTC)
 {% endtab %}
 {% endtabs %}
 
-Frozen; awaiting an activation timestamp on both networks.
 Unified per-opcode [gas metering order](../evm/dual-gas-model.md#gas-metering-order), consolidated EIP-7702 authorization accounting with dynamic SALT account-creation gas for net-new authorities, CREATE-frame accounting corrections, [KeylessDeploy](../system-contracts/keyless-deploy.md) sandbox hardening, post-execution fee-reward accounting, [system-originated transaction](../system-contracts/system-tx.md#system-originated-transaction-metering-exemption) metering exemption, extended beneficiary detention / volatile-access coverage, per-log [data size](../evm/resource-accounting.md#data-size) base, forwarded-gas return on compute-limit halts, value self-transfer account-info dedup, [SequencerRegistry](../system-contracts/sequencer-registry.md) v2.0.0 rotation hardening (EIP-712 possession proof + minimum rotation delay).
 
 ### [Rex7](rex7.md)

--- a/docs/spec/upgrades/rex6.md
+++ b/docs/spec/upgrades/rex6.md
@@ -7,20 +7,6 @@ description: Rex6 network upgrade — unified per-opcode gas metering order (sto
 This page is an informative summary of the Rex6 specification.
 For the full normative definition, see the Rex6 spec in the mega-evm repository.
 
-{% tabs %}
-{% tab title="Testnet" %}
-Not yet scheduled
-{% endtab %}
-{% tab title="Mainnet" %}
-Not yet scheduled
-{% endtab %}
-{% endtabs %}
-
-{% hint style="info" %}
-Rex6 is frozen: its semantics no longer change.
-It has no activation timestamp on either network, so both currently execute [Rex5](rex5.md).
-{% endhint %}
-
 ## Summary
 
 Rex6 bundles fourteen changes to gas metering, resource accounting, execution behavior, and system contracts.

--- a/docs/spec/upgrades/rex7.md
+++ b/docs/spec/upgrades/rex7.md
@@ -7,15 +7,6 @@ description: Rex7 network upgrade — the current unstable spec, open for develo
 This page is an informative summary of the Rex7 specification.
 For the full normative definition, see the Rex7 spec in the mega-evm repository.
 
-{% tabs %}
-{% tab title="Testnet" %}
-Not yet scheduled
-{% endtab %}
-{% tab title="Mainnet" %}
-Not yet scheduled
-{% endtab %}
-{% endtabs %}
-
 {% hint style="warning" %}
 **Unstable** — Rex7 is under active development.
 Anything recorded on this page may change before Rex7 is frozen, and nothing here should be relied on.


### PR DESCRIPTION
## Summary

Rex6 activates at `1786330800` (Aug 10, 2026, 03:00 UTC) on testnet and `1787626800` (Aug 25, 2026, 03:00 UTC) on mainnet. The upgrade overview carries the timestamps, and the three places that described Rex6 as frozen-but-unscheduled now describe it as scheduled — the sentence on `hardfork-spec.md` that illustrated the frozen/activated distinction with an unscheduled spec now names Rex7, which is the unscheduled one.

The Rex6 and Rex7 pages also drop their activation tabs. No other upgrade page has them: activation timestamps live in `upgrades/overview.md` alone, one tab block per upgrade, so the two pages added for the unscheduled state were the odd ones out. Both now open at `## Summary` like every page from MiniRex through Rex5.

## Not in this PR

`block/chain.rs` still has Rex6 at `ForkCondition::Never` on both canonical schedules, and `test_canonical_schedules_do_not_activate_rex6_or_rex7` still pins that. Scheduling it there additionally requires a governance-approved `rex6_min_rotation_delay` for each network — the value written to the registry's `_minRotationDelay` slot at the activation block, which `SequencerRegistryRex6Config::validate` rejects as zero.

Until that lands, `mega-evme replay` resolves an unknown post-activation mainnet or testnet transaction under Rex5, because `hardfork_schedule(chain_id)` is what it reads. Node execution is unaffected: mega-reth resolves forks through its own `MegaethChainSpec`.

## Verification

Swept the repository for any remaining description of Rex6 as unstable, in both directions — Rex6 called unstable, and frozen-boundary statements still stopping at Rex5. Neither exists: every `unstable` mention now names Rex7, and `AGENTS.md`, `evm/spec.rs`, `mutants/operators/spec-gate/generate.py`, `hardfork-spec.md`, `overview.md`, and the `mega-evme` spec table all agree that specs through Rex6 are frozen.

One item is outside the repository: the `spec:unstable` GitHub label still reads "currently REX5" and needs editing in repository settings.

Prettier, markdownlint, and lychee pass.

## Labels

`spec:unchanged`, `comp:doc`, `api:unchanged` — documentation only; no execution path, schedule, or interface changes.
