### PR TITLE
feat: expose sequencer registry pending changes helper

### DIFF
--- a/crates/mega-evm/src/system/sequencer_registry.rs
+++ b/crates/mega-evm/src/system/sequencer_registry.rs
@@ -340,14 +340,15 @@ pub(crate) fn is_apply_pending_changes_due<DB: Database>(
 ///
 /// This single system call applies both the system address change and the sequencer
 /// change if they are due in the current block.
-/// Caller should gate this with [`is_apply_pending_changes_due`] to avoid an EVM
-/// call on every block.
+/// The block executor gates this with its internal due check to avoid an EVM call on every block.
+/// External callers should invoke this only for a known-due pending change and commit the
+/// returned state through their normal pre-block state-change pipeline.
 ///
 /// The system call is issued with `max(block.gas_limit, SYSTEM_CALL_GAS_LIMIT_FLOOR)`
 /// instead of the upstream-fixed 30M. `applyPendingChanges()` writes role-rotation
 /// slots whose actual cost depends on REX dynamic storage gas, so the upstream default
 /// is no longer guaranteed to be enough on activation blocks.
-pub(crate) fn transact_apply_pending_changes<DB, INSP, ExtEnvs>(
+pub fn transact_apply_pending_changes<DB, INSP, ExtEnvs>(
     evm: &mut crate::MegaEvm<DB, INSP, ExtEnvs>,
 ) -> Result<ResultAndState<crate::MegaHaltReason>, BlockExecutionError>
 where

--- a/crates/mega-evm/tests/rex6/sequencer_registry_rotation.rs
+++ b/crates/mega-evm/tests/rex6/sequencer_registry_rotation.rs
@@ -24,10 +24,11 @@ use alloy_primitives::{address, keccak256, Address, Bytes, Signature, TxKind, B2
 use alloy_sol_types::{SolCall, SolValue};
 use mega_evm::{
     test_utils::MemoryDatabase, BlockLimits, ISequencerRegistry, MegaBlockExecutionCtx,
-    MegaBlockExecutorFactory, MegaEvmFactory, MegaHardfork, MegaHardforkConfig, MegaSpecId,
-    MegaTxEnvelope, SequencerRegistryConfig, SequencerRegistryRex6Config, TestExternalEnvs,
-    MEGA_SYSTEM_ADDRESS, SEQUENCER_REGISTRY_ADDRESS, SEQUENCER_REGISTRY_CODE,
-    SEQUENCER_REGISTRY_CODE_HASH, SEQUENCER_REGISTRY_CODE_HASH_REX6,
+    MegaBlockExecutorFactory, MegaContext, MegaEvm, MegaEvmFactory, MegaHardfork,
+    MegaHardforkConfig, MegaSpecId, MegaTxEnvelope, SequencerRegistryConfig,
+    SequencerRegistryRex6Config, TestExternalEnvs, MEGA_SYSTEM_ADDRESS,
+    SEQUENCER_REGISTRY_ADDRESS, SEQUENCER_REGISTRY_CODE, SEQUENCER_REGISTRY_CODE_HASH,
+    SEQUENCER_REGISTRY_CODE_HASH_REX6, transact_apply_pending_changes,
 };
 use mega_system_contracts::sequencer_registry::storage_slots::{
     ADMIN, CURRENT_SEQUENCER, CURRENT_SYSTEM_ADDRESS, MIN_ROTATION_DELAY, PENDING_SEQUENCER,
@@ -37,6 +38,7 @@ use revm::{
     context::BlockEnv,
     database::State,
     state::{AccountInfo, Bytecode},
+    DatabaseCommit,
 };
 
 const CHAIN_ID: u64 = 8453;
@@ -233,6 +235,51 @@ fn seed_v1_registry_with_pending_rotation(
     ] {
         db.insert_account_storage(SEQUENCER_REGISTRY_ADDRESS, slot, value).unwrap();
     }
+}
+
+/// An external caller must be able to apply a v1-scheduled rotation in the Rex6 block before
+/// the separate pre-block path upgrades the registry bytecode to v2.0.0.
+#[test]
+fn test_public_apply_pending_changes_executes_v1_registry_before_rex6_deploy() {
+    let (new_sequencer, _) = new_sequencer_keypair();
+    let activation_block = 1000u64;
+
+    let mut db = MemoryDatabase::default();
+    seed_v1_registry_with_pending_rotation(&mut db, new_sequencer, activation_block);
+
+    let block = BlockEnv {
+        number: U256::from(activation_block),
+        timestamp: U256::from(1_800_000_000u64),
+        gas_limit: 30_000_000,
+        ..Default::default()
+    };
+    let mut context = MegaContext::new(&mut db, MegaSpecId::REX6).with_block(block);
+    context.modify_chain(|chain| {
+        chain.operator_fee_scalar = Some(U256::ZERO);
+        chain.operator_fee_constant = Some(U256::ZERO);
+    });
+
+    let state = {
+        let mut evm = MegaEvm::new(context);
+        transact_apply_pending_changes(&mut evm)
+            .expect("the public helper must apply the due v1 rotation")
+            .state
+    };
+    db.commit(state);
+
+    let mut state = State::builder().with_database(&mut db).build();
+    assert_eq!(
+        registry_code_hash(&mut state),
+        SEQUENCER_REGISTRY_CODE_HASH,
+        "the helper must not perform the separate Rex6 bytecode upgrade"
+    );
+    assert_eq!(
+        read_registry_slot(&mut state, CURRENT_SEQUENCER),
+        U256::from_be_bytes(new_sequencer.into_word().0),
+        "the due v1-scheduled rotation must be committed"
+    );
+    assert_eq!(read_registry_slot(&mut state, PENDING_SEQUENCER), U256::ZERO);
+    assert_eq!(read_registry_slot(&mut state, SEQUENCER_ACTIVATION_BLOCK), U256::ZERO);
 }
 
 /// Fresh chain at Rex6: the pre-block deploy installs v2.0.0 directly with the full seed

--- a/crates/mega-evm/tests/rex6/sequencer_registry_rotation.rs
+++ b/crates/mega-evm/tests/rex6/sequencer_registry_rotation.rs
@@ -23,12 +23,11 @@ use alloy_op_evm::block::receipt_builder::OpAlloyReceiptBuilder;
 use alloy_primitives::{address, keccak256, Address, Bytes, Signature, TxKind, B256, U256};
 use alloy_sol_types::{SolCall, SolValue};
 use mega_evm::{
-    test_utils::MemoryDatabase, BlockLimits, ISequencerRegistry, MegaBlockExecutionCtx,
-    MegaBlockExecutorFactory, MegaContext, MegaEvm, MegaEvmFactory, MegaHardfork,
-    MegaHardforkConfig, MegaSpecId, MegaTxEnvelope, SequencerRegistryConfig,
-    SequencerRegistryRex6Config, TestExternalEnvs, MEGA_SYSTEM_ADDRESS,
-    SEQUENCER_REGISTRY_ADDRESS, SEQUENCER_REGISTRY_CODE, SEQUENCER_REGISTRY_CODE_HASH,
-    SEQUENCER_REGISTRY_CODE_HASH_REX6, transact_apply_pending_changes,
+    test_utils::MemoryDatabase, transact_apply_pending_changes, BlockLimits, ISequencerRegistry,
+    MegaBlockExecutionCtx, MegaBlockExecutorFactory, MegaContext, MegaEvm, MegaEvmFactory,
+    MegaHardfork, MegaHardforkConfig, MegaSpecId, MegaTxEnvelope, SequencerRegistryConfig,
+    SequencerRegistryRex6Config, TestExternalEnvs, MEGA_SYSTEM_ADDRESS, SEQUENCER_REGISTRY_ADDRESS,
+    SEQUENCER_REGISTRY_CODE, SEQUENCER_REGISTRY_CODE_HASH, SEQUENCER_REGISTRY_CODE_HASH_REX6,
 };
 use mega_system_contracts::sequencer_registry::storage_slots::{
     ADMIN, CURRENT_SEQUENCER, CURRENT_SYSTEM_ADDRESS, MIN_ROTATION_DELAY, PENDING_SEQUENCER,


### PR DESCRIPTION
## Summary

- Expose the existing typed SequencerRegistry pending-change helper for external pre-block executors.
- Document that callers invoke it only for known-due changes and commit its returned state through their normal pipeline.
- Add an integration test for applying a v1-scheduled rotation under Rex6 before the separate v2 deployment.

## Testing

- cargo fmt --all --check
- cargo check -p mega-evm
- cargo test -p mega-evm
- cargo clippy --workspace --lib --examples --tests --benches --all-features --locked
- cherry-pick and focused test on current upstream main

The branch is rooted at v1.7.0 so downstream users can pin this API without Rex7 changes.