### PR TITLE
fix(chain): schedule Rex6 on the canonical mainnet and testnet hardfork schedules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ Progression: `EQUIVALENCE` → `MINI_REX` → `MINI_REX_1` → `MINI_REX_2` → 
   - _`REX7` is the current unstable spec under active development._
     When a new spec is introduced, this line should be updated to indicate the unstable spec.
   - Frozen and activated are separate properties.
-    `REX6` is frozen and activated on both networks (testnet `1786330800`, mainnet `1787626800`); `REX7` has no activation timestamp yet.
-    Freezing forbids further semantic change; scheduling is a later, separate decision, recorded in `block/chain.rs`.
+    `REX6` is frozen and activated on both networks (see `block/chain.rs`); `REX7` has no activation timestamp yet.
+    Freezing forbids further semantic change; scheduling is a later, separate decision made in the node chainspecs and mirrored here in `block/chain.rs` for replay tooling.
   - Specifications of each behavior-introducing spec can be found in the upgrade pages under `docs/spec/upgrades/`; alias rungs have no page of their own and are recorded in the upgrade overview and `docs/spec/hardfork-spec.md`.
 - **Hardfork** (`MegaHardfork`) defines network upgrade events (when specs activate).
   Every hardfork schedules a spec rung of its own — the fork→spec mapping is 1:1.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ Progression: `EQUIVALENCE` → `MINI_REX` → `REX` → `REX1` → `REX2` → `R
   - _`REX7` is the current unstable spec under active development._
     When a new spec is introduced, this line should be updated to indicate the unstable spec.
   - Frozen and activated are separate properties.
-    `REX6` is frozen but has no activation timestamp on mainnet or testnet, so both chains still execute `REX5`.
-    Freezing forbids further semantic change; scheduling is a later, separate decision.
+    `REX6` is frozen and activated on both networks (testnet `1786330800`, mainnet `1787626800`); `REX7` has no activation timestamp yet.
+    Freezing forbids further semantic change; scheduling is a later, separate decision, recorded in `block/chain.rs`.
   - Specifications of each spec can be found in the upgrade pages under `docs/spec/upgrades/`.
 - **Hardfork** (`MegaHardfork`) defines network upgrade events (when specs activate).
   Multiple hardforks can map to one spec.
@@ -307,7 +307,7 @@ When the agent is requested to implement a new feature or bug fix, it should con
   If editing nearby tests in the same module, align names to the same `test_` style when reasonable.
 - **Do NOT modify behavior for existing stable specs.**
   All specs through `REX6` are frozen; `REX7` is the unstable spec under active development.
-  A spec being frozen is independent of whether any network has scheduled it — `REX6` is frozen and unscheduled, and is still off-limits to behavior changes.
+  A spec being frozen is independent of whether any network has scheduled it — a frozen spec is off-limits to behavior changes whether or not a timestamp has been published.
   New EVM behavior, gas cost changes, or opcode modifications for stable specs **must** introduce a new spec and be gated with `spec.is_enabled(MegaSpecId::NEW_SPEC)`.
   Never change what an existing stable spec does.
 - **System contract changes require a new spec.**

--- a/crates/mega-evm/src/block/chain.rs
+++ b/crates/mega-evm/src/block/chain.rs
@@ -5,8 +5,9 @@
 //! `mega-evme` replay command, Foundry-based tooling, integration tests) should
 //! use [`hardfork_schedule`] rather than re-declaring timestamps locally.
 //!
-//! Per-fork parameters that are chain-specific data — currently the
-//! [`SequencerRegistryConfig`] seeded at Rex5 activation — are attached here too.
+//! Per-fork parameters that are chain-specific data — the
+//! [`SequencerRegistryConfig`] seeded at Rex5 activation and the
+//! [`SequencerRegistryRex6Config`] seeded at Rex6 activation — are attached here too.
 
 use alloy_hardforks::ForkCondition;
 use alloy_primitives::address;
@@ -34,6 +35,7 @@ pub fn mainnet_hardforks() -> MegaHardforkConfig {
         .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771639200))
         .with(MegaHardfork::Rex4, ForkCondition::Timestamp(1776659200))
         .with(MegaHardfork::Rex5, ForkCondition::Timestamp(1780632000))
+        .with(MegaHardfork::Rex6, ForkCondition::Timestamp(1787626800))
         // Seeded values read from the on-chain SequencerRegistry (0x6342…0006) at
         // Rex5 init: INITIAL_SEQUENCER (slot 5) and the admin (slot 2). At replay
         // time these only satisfy the activation guard — the live system address
@@ -42,6 +44,11 @@ pub fn mainnet_hardforks() -> MegaHardforkConfig {
             rex5_initial_sequencer: address!("0x7a49197dd1ebb8d38c67e4eb7626af6ade432445"),
             rex5_initial_admin: address!("0x92e0e0b15e3e99b32c9ed9ad284f939553c7b7d6"),
         })
+        // Governance parameter seeded into the v2.0.0 registry at Rex6 init: the
+        // minimum scheduling-to-activation delay (`_minRotationDelay`), in blocks.
+        // Must equal the `rex6MinRotationDelay` the operator genesis attaches; the
+        // live value is readable via `minRotationDelay()` on 0x6342…0006.
+        .with_params(SequencerRegistryRex6Config { rex6_min_rotation_delay: 21600 })
 }
 
 /// Canonical hardfork schedule for `MegaETH` testnet v2 (chain `6343`).
@@ -56,6 +63,7 @@ pub fn testnet_hardforks() -> MegaHardforkConfig {
         .with(MegaHardfork::Rex3, ForkCondition::Timestamp(1771380000))
         .with(MegaHardfork::Rex4, ForkCondition::Timestamp(1776400000))
         .with(MegaHardfork::Rex5, ForkCondition::Timestamp(1780459200))
+        .with(MegaHardfork::Rex6, ForkCondition::Timestamp(1786330800))
         // Seeded values read from the on-chain SequencerRegistry (0x6342…0006) at
         // Rex5 init on testnet: INITIAL_SEQUENCER (slot 5) and the admin (slot 2).
         // At replay time these only satisfy the activation guard — the live system
@@ -64,6 +72,11 @@ pub fn testnet_hardforks() -> MegaHardforkConfig {
             rex5_initial_sequencer: address!("0xB8DB54eBA7Ae650d14F362de461516a4FF1551FC"),
             rex5_initial_admin: address!("0x1d9BD232C44B39341e670B735c7F423c40426b34"),
         })
+        // Governance parameter seeded into the v2.0.0 registry at Rex6 init: the
+        // minimum scheduling-to-activation delay (`_minRotationDelay`), in blocks.
+        // Must equal the `rex6MinRotationDelay` the operator genesis attaches; the
+        // live value is readable via `minRotationDelay()` on 0x6342…0006.
+        .with_params(SequencerRegistryRex6Config { rex6_min_rotation_delay: 21600 })
 }
 
 /// All `MegaETH` hardforks activated at genesis.
@@ -120,8 +133,12 @@ mod tests {
         // Just before Rex5, still Rex4; at/after Rex5, Rex5.
         assert_eq!(hf.spec_id(1780631999), MegaSpecId::REX4);
         assert_eq!(hf.spec_id(1780632000), MegaSpecId::REX5);
-        // Rex5 carries the SequencerRegistryConfig.
+        // Just before Rex6, still Rex5; at/after Rex6, Rex6.
+        assert_eq!(hf.spec_id(1787626799), MegaSpecId::REX5);
+        assert_eq!(hf.spec_id(1787626800), MegaSpecId::REX6);
+        // Rex5 carries the SequencerRegistryConfig, Rex6 the SequencerRegistryRex6Config.
         assert!(hf.fork_params::<SequencerRegistryConfig>().is_some());
+        assert!(hf.fork_params::<SequencerRegistryRex6Config>().is_some());
     }
 
     #[test]
@@ -131,29 +148,45 @@ mod tests {
         // Just before Rex5, still Rex4; at/after Rex5, Rex5.
         assert_eq!(hf.spec_id(1780459199), MegaSpecId::REX4);
         assert_eq!(hf.spec_id(1780459200), MegaSpecId::REX5);
-        // Rex5 carries the SequencerRegistryConfig.
+        // Just before Rex6, still Rex5; at/after Rex6, Rex6.
+        assert_eq!(hf.spec_id(1786330799), MegaSpecId::REX5);
+        assert_eq!(hf.spec_id(1786330800), MegaSpecId::REX6);
+        // Rex5 carries the SequencerRegistryConfig, Rex6 the SequencerRegistryRex6Config.
         assert!(hf.fork_params::<SequencerRegistryConfig>().is_some());
+        assert!(hf.fork_params::<SequencerRegistryRex6Config>().is_some());
     }
 
     #[test]
     fn test_schedule_dispatch_by_chain_id() {
         assert_eq!(hardfork_schedule(MAINNET_CHAIN_ID).spec_id(1780632000), MegaSpecId::REX5);
         assert_eq!(hardfork_schedule(TESTNET_CHAIN_ID).spec_id(1780459200), MegaSpecId::REX5);
+        assert_eq!(hardfork_schedule(MAINNET_CHAIN_ID).spec_id(1787626800), MegaSpecId::REX6);
+        assert_eq!(hardfork_schedule(TESTNET_CHAIN_ID).spec_id(1786330800), MegaSpecId::REX6);
         // Unknown chain: everything active at genesis, including the unstable REX7.
         assert_eq!(hardfork_schedule(1).spec_id(0), MegaSpecId::REX7);
     }
 
     #[test]
-    fn test_canonical_schedules_do_not_activate_rex6_or_rex7() {
-        // Rex6 is frozen but has no published activation date on either network,
-        // and Rex7 is still unstable. Neither may appear in a canonical schedule
+    fn test_canonical_schedules_activate_rex6_and_pin_rex7_never() {
+        // Rex6 is scheduled on both networks at the published timestamps (testnet
+        // 2026-08-10, mainnet 2026-08-25) and carries the governance-seeded rotation
+        // delay. Rex7 is still unstable and must not appear in a canonical schedule
         // until governance publishes a timestamp: an accidental entry here would
         // fork the live chains at that timestamp.
-        for hf in [mainnet_hardforks(), testnet_hardforks()] {
-            assert_eq!(hf.mega_fork_activation(MegaHardfork::Rex6), ForkCondition::Never);
+        for (hf, rex6_activation) in
+            [(mainnet_hardforks(), 1787626800), (testnet_hardforks(), 1786330800)]
+        {
+            assert_eq!(
+                hf.mega_fork_activation(MegaHardfork::Rex6),
+                ForkCondition::Timestamp(rex6_activation)
+            );
             assert_eq!(hf.mega_fork_activation(MegaHardfork::Rex7), ForkCondition::Never);
-            // Rex5 is therefore the terminal spec on both chains, at any timestamp.
-            assert_eq!(hf.spec_id(u64::MAX), MegaSpecId::REX5);
+            // Rex6 is therefore the terminal spec on both chains, at any later timestamp.
+            assert_eq!(hf.spec_id(u64::MAX), MegaSpecId::REX6);
+            let params = hf
+                .fork_params::<SequencerRegistryRex6Config>()
+                .expect("canonical schedules must carry a SequencerRegistryRex6Config");
+            assert_eq!(params.rex6_min_rotation_delay, 21600);
         }
     }
 

--- a/crates/mega-evm/src/block/chain.rs
+++ b/crates/mega-evm/src/block/chain.rs
@@ -23,6 +23,14 @@ pub const MAINNET_CHAIN_ID: u64 = 4326;
 /// `MegaETH` testnet v2 chain ID.
 pub const TESTNET_CHAIN_ID: u64 = 6343;
 
+/// Governance parameter seeded into the v2.0.0 `SequencerRegistry` at Rex6 init on both
+/// live networks: the minimum scheduling-to-activation delay (`_minRotationDelay`), in
+/// blocks. Must equal the `rex6MinRotationDelay` the operator genesis attaches; the live
+/// value is readable via `minRotationDelay()` on `0x6342…0006`. One constant for both
+/// schedules, so a network diverging from the other is a deliberate edit rather than a
+/// silent difference.
+const REX6_MIN_ROTATION_DELAY: u64 = 21_600;
+
 /// Canonical hardfork schedule for `MegaETH` mainnet (chain `4326`).
 pub fn mainnet_hardforks() -> MegaHardforkConfig {
     MegaHardforkConfig::new()
@@ -44,11 +52,9 @@ pub fn mainnet_hardforks() -> MegaHardforkConfig {
             rex5_initial_sequencer: address!("0x7a49197dd1ebb8d38c67e4eb7626af6ade432445"),
             rex5_initial_admin: address!("0x92e0e0b15e3e99b32c9ed9ad284f939553c7b7d6"),
         })
-        // Governance parameter seeded into the v2.0.0 registry at Rex6 init: the
-        // minimum scheduling-to-activation delay (`_minRotationDelay`), in blocks.
-        // Must equal the `rex6MinRotationDelay` the operator genesis attaches; the
-        // live value is readable via `minRotationDelay()` on 0x6342…0006.
-        .with_params(SequencerRegistryRex6Config { rex6_min_rotation_delay: 21600 })
+        .with_params(SequencerRegistryRex6Config {
+            rex6_min_rotation_delay: REX6_MIN_ROTATION_DELAY,
+        })
 }
 
 /// Canonical hardfork schedule for `MegaETH` testnet v2 (chain `6343`).
@@ -72,11 +78,9 @@ pub fn testnet_hardforks() -> MegaHardforkConfig {
             rex5_initial_sequencer: address!("0xB8DB54eBA7Ae650d14F362de461516a4FF1551FC"),
             rex5_initial_admin: address!("0x1d9BD232C44B39341e670B735c7F423c40426b34"),
         })
-        // Governance parameter seeded into the v2.0.0 registry at Rex6 init: the
-        // minimum scheduling-to-activation delay (`_minRotationDelay`), in blocks.
-        // Must equal the `rex6MinRotationDelay` the operator genesis attaches; the
-        // live value is readable via `minRotationDelay()` on 0x6342…0006.
-        .with_params(SequencerRegistryRex6Config { rex6_min_rotation_delay: 21600 })
+        .with_params(SequencerRegistryRex6Config {
+            rex6_min_rotation_delay: REX6_MIN_ROTATION_DELAY,
+        })
 }
 
 /// All `MegaETH` hardforks activated at genesis.

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -109,7 +109,7 @@
 //!   must be included in blocks regardless of their DA size to maintain bridge integrity
 //! - **Tracking**: Deposit DA sizes are **not** accumulated into the block DA usage counter
 //!   (`post_execution_update` skips them), so `block_da_size_used` reflects non-deposit
-//!   transactions only; operators estimating L1 posting cost must add deposits separately
+//!   transactions only
 //! - **Other Limits**: Deposit transactions are still subject to all other limits (gas, tx size,
 //!   compute gas, data size, KV updates)
 //!

--- a/crates/mega-evm/src/block/limit.rs
+++ b/crates/mega-evm/src/block/limit.rs
@@ -107,8 +107,9 @@
 //!   block-level Data Availability size limit checks during pre-execution validation
 //! - **Rationale**: Deposit transactions are trustless L1→L2 messages that cannot be censored. They
 //!   must be included in blocks regardless of their DA size to maintain bridge integrity
-//! - **Tracking**: While exempt from limit checks, deposit DA sizes are still tracked and
-//!   accumulated in block DA usage counters for monitoring purposes
+//! - **Tracking**: Deposit DA sizes are **not** accumulated into the block DA usage counter
+//!   (`post_execution_update` skips them), so `block_da_size_used` reflects non-deposit
+//!   transactions only; operators estimating L1 posting cost must add deposits separately
 //! - **Other Limits**: Deposit transactions are still subject to all other limits (gas, tx size,
 //!   compute gas, data size, KV updates)
 //!

--- a/crates/mega-evm/tests/block_executor/canonical_schedule.rs
+++ b/crates/mega-evm/tests/block_executor/canonical_schedule.rs
@@ -1,0 +1,136 @@
+//! Pins the canonical per-chain schedules (`block/chain.rs`) to the activation timestamps
+//! published in `docs/spec/upgrades/overview.md`.
+//!
+//! The two are separate copies of the same numbers: the overview is what operators and
+//! integrators read, the schedule is what `mega-evme replay` executes. A digit mistyped in
+//! either is self-consistent with its own tests, so this test reads the published table and
+//! compares every fork on both networks — a backticked timestamp in the overview must be the
+//! schedule entry, and a fork the overview marks as not activated (`N/A`, `Not yet scheduled`)
+//! must be [`ForkCondition::Never`].
+
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use alloy_hardforks::ForkCondition;
+use mega_evm::{mainnet_hardforks, testnet_hardforks, MegaHardfork, MegaHardforks};
+
+/// Every fork heading in the published upgrade overview and the hardfork it documents. A new
+/// fork page must be added here to be pinned; the test fails if the two sets differ.
+const FORK_PAGES: &[(&str, MegaHardfork)] = &[
+    ("MiniRex", MegaHardfork::MiniRex),
+    ("MiniRex1", MegaHardfork::MiniRex1),
+    ("MiniRex2", MegaHardfork::MiniRex2),
+    ("Rex", MegaHardfork::Rex),
+    ("Rex1", MegaHardfork::Rex1),
+    ("Rex2", MegaHardfork::Rex2),
+    ("Rex3", MegaHardfork::Rex3),
+    ("Rex4", MegaHardfork::Rex4),
+    ("Rex5", MegaHardfork::Rex5),
+    ("Rex6", MegaHardfork::Rex6),
+    ("Rex7", MegaHardfork::Rex7),
+];
+
+/// Published activation per network as written in the overview: `Some(ts)` for a backticked
+/// timestamp, `None` for the prose that marks a fork as not activated on that network.
+#[derive(Debug, Default)]
+struct Published {
+    testnet: Option<u64>,
+    mainnet: Option<u64>,
+}
+
+#[derive(Clone, Copy)]
+enum Network {
+    Testnet,
+    Mainnet,
+}
+
+fn overview_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/spec/upgrades/overview.md")
+}
+
+/// Parses the `## Hardfork History` section. Each `### <Fork>` heading (linked or bare) opens an
+/// entry; the line after `{% tab title="Testnet" %}` / `{% tab title="Mainnet" %}` carries either
+/// a backticked timestamp or a not-activated marker.
+fn parse_published(overview: &str) -> BTreeMap<String, Published> {
+    let mut out: BTreeMap<String, Published> = BTreeMap::new();
+    let mut current: Option<String> = None;
+    let mut in_history = false;
+    let mut lines = overview.lines();
+    while let Some(line) = lines.next() {
+        if let Some(heading) = line.strip_prefix("## ") {
+            in_history = heading.trim() == "Hardfork History";
+            current = None;
+            continue;
+        }
+        if !in_history {
+            continue;
+        }
+        if let Some(heading) = line.strip_prefix("### ") {
+            let heading = heading.trim();
+            // `### [Rex6](rex6.md)` and `### MiniRex1` both name the fork.
+            let label = heading
+                .strip_prefix('[')
+                .and_then(|rest| rest.split(']').next())
+                .unwrap_or(heading);
+            out.entry(label.to_string()).or_default();
+            current = Some(label.to_string());
+            continue;
+        }
+        let network = match line.trim() {
+            "{% tab title=\"Testnet\" %}" => Network::Testnet,
+            "{% tab title=\"Mainnet\" %}" => Network::Mainnet,
+            _ => continue,
+        };
+        let body = lines.next().expect("a tab has a body line").trim();
+        let timestamp = body.strip_prefix('`').map(|rest| {
+            let digits = rest.split('`').next().expect("closing backtick");
+            digits.parse::<u64>().unwrap_or_else(|e| panic!("bad timestamp {digits:?}: {e}"))
+        });
+        let label = current.as_ref().expect("a tab outside any fork heading");
+        let entry = out.get_mut(label).expect("entry created at the heading");
+        match network {
+            Network::Testnet => entry.testnet = timestamp,
+            Network::Mainnet => entry.mainnet = timestamp,
+        }
+    }
+    out
+}
+
+fn expected(published: Option<u64>) -> ForkCondition {
+    published.map_or(ForkCondition::Never, ForkCondition::Timestamp)
+}
+
+#[test]
+fn test_canonical_schedules_match_published_activation_timestamps() {
+    let overview = fs::read_to_string(overview_path())
+        .expect("docs/spec/upgrades/overview.md is part of the repository");
+    let published = parse_published(&overview);
+
+    // Every documented fork is pinned, and every pinned fork is documented.
+    let documented: Vec<&str> = published.keys().map(String::as_str).collect();
+    let mut pinned: Vec<&str> = FORK_PAGES.iter().map(|(label, _)| *label).collect();
+    pinned.sort_unstable();
+    assert_eq!(
+        documented, pinned,
+        "overview.md fork pages and FORK_PAGES differ — extend the pin when a fork page is added"
+    );
+
+    let mainnet = mainnet_hardforks();
+    let testnet = testnet_hardforks();
+    for (label, fork) in FORK_PAGES {
+        let doc = &published[*label];
+        assert_eq!(
+            testnet.mega_fork_activation(*fork),
+            expected(doc.testnet),
+            "{label}: testnet schedule in block/chain.rs disagrees with overview.md"
+        );
+        assert_eq!(
+            mainnet.mega_fork_activation(*fork),
+            expected(doc.mainnet),
+            "{label}: mainnet schedule in block/chain.rs disagrees with overview.md"
+        );
+    }
+}

--- a/crates/mega-evm/tests/block_executor/canonical_schedule.rs
+++ b/crates/mega-evm/tests/block_executor/canonical_schedule.rs
@@ -47,8 +47,23 @@ enum Network {
     Mainnet,
 }
 
-fn overview_path() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR")).join("../../docs/spec/upgrades/overview.md")
+/// The overview lives outside the crate root, so it is not part of the published package.
+/// Returns `None` when this crate is not laid out as a repository checkout (a crates.io tarball
+/// or a vendored copy), where the pin has nothing to compare against; in a checkout the file is
+/// mandatory and its absence fails the test.
+fn overview() -> Option<String> {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    if !workspace_root.join("crates/mega-evm/Cargo.toml").is_file() {
+        eprintln!(
+            "skipping: not a repository checkout, docs/spec/upgrades/overview.md is not packaged"
+        );
+        return None;
+    }
+    let path: PathBuf = workspace_root.join("docs/spec/upgrades/overview.md");
+    Some(
+        fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("{} is part of the repository: {e}", path.display())),
+    )
 }
 
 /// Parses the `## Hardfork History` section. Each `### <Fork>` heading (linked or bare) opens an
@@ -105,8 +120,7 @@ fn expected(published: Option<u64>) -> ForkCondition {
 
 #[test]
 fn test_canonical_schedules_match_published_activation_timestamps() {
-    let overview = fs::read_to_string(overview_path())
-        .expect("docs/spec/upgrades/overview.md is part of the repository");
+    let Some(overview) = overview() else { return };
     let published = parse_published(&overview);
 
     // Every documented fork is pinned, and every pinned fork is documented.

--- a/crates/mega-evm/tests/block_executor/main.rs
+++ b/crates/mega-evm/tests/block_executor/main.rs
@@ -2,6 +2,7 @@
 
 mod accessed_block_hashes;
 mod block_limits;
+mod canonical_schedule;
 mod deposit_da_exemption;
 mod inspector;
 mod partial_ladder;


### PR DESCRIPTION
## Summary

Schedule Rex6 on the canonical mainnet / testnet hardfork schedules in `block/chain.rs`, so `mega-evme replay` (which resolves the spec through `hardfork_schedule`) stops applying Rex5 rules to blocks after the activation timestamps; drop the stale "Rex6 is unscheduled" prose; and fix a wrong module-doc sentence in `block/limit.rs` about deposit DA accounting.

## Why

Both networks have been executing Rex6 since the published timestamps — testnet `1786330800` (2026-08-10), mainnet `1787626800` (2026-08-25); the on-chain `SequencerRegistry` (`0x6342…0006`) reports `version() == "2.0.0"` and `minRotationDelay() == 21600` on both. #364 published the timestamps in `docs/`, but `chain.rs` still pinned Rex6 as `Never` and a test asserted it, so every replay of a post-activation block ran the wrong spec. Consensus is unaffected (mega-reth derives forks from genesis); this is replay/tooling correctness.

Found by the Fenz.AI 2026-09-02 audit (F-016 / `ME-FE-20260902-016`, F-023 / `ME-FE-20260902-023`).

## Changes

- `block/chain.rs`: `Rex6` entries for mainnet and testnet, each with `SequencerRegistryRex6Config { rex6_min_rotation_delay: 21600 }` (the governance value the operator genesis attaches; readable live via `minRotationDelay()`). Module doc mentions the Rex6 params.
- Tests: `test_mainnet_/test_testnet_schedule_resolves_specs_by_timestamp` and `test_schedule_dispatch_by_chain_id` pin the Rex5→Rex6 boundary; `test_canonical_schedules_do_not_activate_rex6_or_rex7` becomes `test_canonical_schedules_activate_rex6_and_pin_rex7_never` (Rex6 at the published timestamps with delay 21600, Rex7 still `Never`, Rex6 terminal).
- `AGENTS.md`: Rex6 is frozen **and** activated; the "frozen ≠ scheduled" rule stays, without naming Rex6 as the unscheduled example.
- `block/limit.rs`: module doc said deposit DA sizes are "still tracked and accumulated in block DA usage counters"; `post_execution_update` skips deposits, so the doc now says so.

No behaviour change for any spec; no `docs/` change (already published in #364).

## Verification

- `cargo test -p mega-evm --lib` — 262 passed
- `cargo test -p mega-evm --test mutation -- hardfork_schedule` — 2 passed
- `cargo clippy --workspace --lib --examples --tests --benches --all-features --locked`, `cargo fmt --all --check` — clean
