### PR TITLE
ci(on-release): read publish credentials from the publish environment

### DIFF
--- a/.claude/skills/bump-version-release/SKILL.md
+++ b/.claude/skills/bump-version-release/SKILL.md
@@ -18,6 +18,7 @@ Releases are made by the org release pipeline (megaeth-labs/.github).
 3. **Publish** — automatic on that merge.
    It creates the annotated tag `vX.Y.Z` and the GitHub Release with the entry as notes.
 4. **Targets** — automatic on the Release: `on-release.yml` publishes the four crates to crates.io and uploads `mega-evme` to the MegaETH artifact registry and the Release page.
-   Rehearse it first on an existing tag: `gh workflow run on-release.yml -f tag=vX.Y.Z -f dry_run=true`.
+   Rehearse it first on an existing tag, dispatching on that tag's ref: `gh workflow run on-release.yml --ref vX.Y.Z -f tag=vX.Y.Z -f dry_run=true`.
+   The publish credentials live in the `publish` environment, which only runs on `v*` tag refs may use.
 
 Do not create tags or Releases by hand; the tag ruleset rejects it.

--- a/.claude/skills/bump-version-release/SKILL.md
+++ b/.claude/skills/bump-version-release/SKILL.md
@@ -18,7 +18,8 @@ Releases are made by the org release pipeline (megaeth-labs/.github).
 3. **Publish** — automatic on that merge.
    It creates the annotated tag `vX.Y.Z` and the GitHub Release with the entry as notes.
 4. **Targets** — automatic on the Release: `on-release.yml` publishes the four crates to crates.io and uploads `mega-evme` to the MegaETH artifact registry and the Release page.
-   Rehearse it first on an existing tag, dispatching on that tag's ref: `gh workflow run on-release.yml --ref vX.Y.Z -f tag=vX.Y.Z -f dry_run=true`.
-   The publish credentials live in the `publish` environment, which only runs on `v*` tag refs may use.
+   Rehearse it first on an existing tag, dispatching on that tag's ref: `gh workflow run on-release.yml --ref vX.Y.Z -f dry_run=true`.
+   The tag being released is always the run's own ref; there is no separate tag input.
+   The publish credentials live in the `publish` environment, whose deployment policy allows only `v*` tag refs.
 
 Do not create tags or Releases by hand; the tag ruleset rejects it.

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -9,6 +9,13 @@ name: On Release
 #   crates    — the four published crates to crates.io (replaces publish.yml)
 #   mega-evme — the CLI binary to the MegaETH artifact registry and, as a
 #               download for the public, to the GitHub Release page
+#
+# Rehearse on a tag ref (the environment below allows only v* tag refs):
+#   gh workflow run on-release.yml --ref vX.Y.Z -f tag=vX.Y.Z -f dry_run=true
+#
+# Credentials (CARGO_REGISTRY_TOKEN, GCP_AUTH_KEY) live in the `publish`
+# environment, whose deployment policy allows only v* tags: a job can read
+# them only when the run's ref is a release tag, never from a branch build.
 
 on:
   release:
@@ -37,6 +44,7 @@ jobs:
   crates:
     runs-on: ubuntu-24.04
     timeout-minutes: 40
+    environment: publish
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -66,6 +74,7 @@ jobs:
   mega-evme:
     runs-on: ubuntu-24.04
     timeout-minutes: 40
+    environment: publish
     permissions:
       contents: write # release-assets attaches to the Release
     steps:

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -11,7 +11,9 @@ name: On Release
 #               download for the public, to the GitHub Release page
 #
 # Rehearse on a tag ref (the environment below allows only v* tag refs):
-#   gh workflow run on-release.yml --ref vX.Y.Z -f tag=vX.Y.Z -f dry_run=true
+#   gh workflow run on-release.yml --ref vX.Y.Z -f dry_run=true
+# The tag being released is always the run's own ref: the environment
+# authorises that ref, so nothing else may be checked out or published.
 #
 # Credentials (CARGO_REGISTRY_TOKEN, GCP_AUTH_KEY) live in the `publish`
 # environment, whose deployment policy allows only v* tags: a job can read
@@ -22,10 +24,6 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Existing tag to run against (rehearsal)"
-        required: true
-        type: string
       dry_run:
         description: "Verify and build everything; publish, upload and attach nothing"
         required: false
@@ -36,7 +34,10 @@ permissions:
   contents: read
 
 env:
-  TAG: ${{ github.event.release.tag_name || inputs.tag }}
+  # The run's ref — the released tag on a release event, the dispatched tag
+  # on a rehearsal. Never an input: the publish environment authorises this
+  # ref, so it must also be what gets built and published.
+  TAG: ${{ github.ref_name }}
   # A release event is never a dry run; a dispatch defaults to one.
   DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
 
@@ -46,6 +47,10 @@ jobs:
     timeout-minutes: 40
     environment: publish
     steps:
+      - name: Require a tag ref
+        run: |
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || { echo "::error::this workflow publishes the run's own ref, which must be a tag (got $GITHUB_REF_TYPE $GITHUB_REF_NAME); dispatch it with --ref vX.Y.Z"; exit 1; }
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.TAG }}
@@ -78,6 +83,10 @@ jobs:
     permissions:
       contents: write # release-assets attaches to the Release
     steps:
+      - name: Require a tag ref
+        run: |
+          [[ "$GITHUB_REF_TYPE" == "tag" ]] || { echo "::error::this workflow publishes the run's own ref, which must be a tag (got $GITHUB_REF_TYPE $GITHUB_REF_NAME); dispatch it with --ref vX.Y.Z"; exit 1; }
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.TAG }}


### PR DESCRIPTION
Both `on-release.yml` jobs now declare `environment: publish`.

## Admin setup (repo Settings → Environments → `publish`)
1. **Deployment branches and tags → Selected branches and tags → add tag pattern `v*`.** This is the control: the environment's secrets are readable only by a run whose ref is a `v*` tag — the `release: published` run, or a rehearsal dispatched on the tag ref — never by a branch build.
2. **Environment secrets**: `CARGO_REGISTRY_TOKEN` (move from repo secrets) and `GCP_AUTH_KEY` (the uploader key). Environment secrets take precedence over repo/org secrets of the same name, so mega-evm can then be dropped from the org secret's selected list.
3. Required reviewers: optional (settlement is already a reviewed PR).

Safe to merge before the setup: with no environment secret present, GitHub falls back to the repo/org secret, so nothing breaks in between.

## Rehearsals
Now dispatched on a tag ref: `gh workflow run on-release.yml --ref v1.7.1 -f tag=v1.7.1 -f dry_run=true` (any tag from `v1.7.1` onward carries the workflow file). Skill text updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)