### PR TITLE
ci(release): concurrency groups; shared verify-version action for mega-evme

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -30,6 +30,13 @@ on:
         type: boolean
         default: true
 
+# One run per tag: a release run and a dispatch on the same tag both end in
+# uploads (`--clobber` on Release assets), so overlapping runs would race.
+# Never cancel an upload mid-flight; queue instead.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 
@@ -102,21 +109,14 @@ jobs:
       - name: Build mega-evme
         run: cargo build --release --locked -p mega-evme
 
-      - name: Verify the binary reports the release version
-        run: |
-          set -euo pipefail
-          expected="mega-evme ${TAG#v}"
-          actual="$(target/release/mega-evme --version)"
-          if [[ "$actual" != "$expected" ]]; then
-            if [[ "$DRY_RUN" == "true" ]]; then
-              # A rehearsal reports what a real run would refuse, and carries on.
-              echo "::warning::built binary reports '$actual', expected '$expected' — a real release would stop here"
-            else
-              echo "::error::built binary reports '$actual', expected '$expected'; refusing to publish a mislabeled binary"
-              exit 1
-            fi
-          fi
-          echo "$actual"
+      # The built binary must report the tag's version (`mega-evme X.Y.Z`):
+      # a mismatch warns on a rehearsal and stops a release; a binary that
+      # cannot run stops both.
+      - uses: megaeth-labs/.github/.github/actions/release-verify-version@main
+        with:
+          command: target/release/mega-evme --version
+          version: ${{ env.TAG }}
+          dry_run: ${{ env.DRY_RUN }}
 
       - uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -17,6 +17,12 @@ on:
     types: [closed]
     branches: [main]
 
+# One candidate at a time: two dispatches would race on the candidate branch,
+# and a cut runs on its own merge and must never be cancelled half-way.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -17,18 +17,20 @@ on:
     types: [closed]
     branches: [main]
 
-# One candidate at a time: two dispatches would race on the candidate branch,
-# and a cut runs on its own merge and must never be cancelled half-way.
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
 jobs:
   propose:
     if: github.event_name == 'workflow_dispatch'
+    # One proposal at a time: two dispatches would race on the candidate
+    # branch. Job-level, not workflow-level: every PR closing on the default
+    # branch also starts this workflow, and a workflow-wide group would let
+    # that noise evict a queued release run (one pending run per group).
+    # A skipped job holds no slot in a job-level group.
+    concurrency:
+      group: ${{ github.workflow }}-propose
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
@@ -66,6 +68,11 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'chore/release-candidate-') &&
       github.event.pull_request.user.login == 'mega-maxwell[bot]'
+    # One cut at a time, never cancelled: pull_request.closed does not refire.
+    # Job-level for the reason given on `propose`.
+    concurrency:
+      group: ${{ github.workflow }}-cut
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,12 +14,6 @@ on:
     types: [closed]
     branches: ["release-v*"]
 
-# One publish per release branch: the tag guard and the tag push are two
-# steps, so a re-run must queue behind a run in flight, never overlap it.
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref }}
-  cancel-in-progress: false
-
 permissions:
   contents: read
 
@@ -29,6 +23,13 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.head.ref, 'chore/release-settle-') &&
       github.event.pull_request.user.login == 'mega-maxwell[bot]'
+    # One publish per release branch: the tag guard and the tag push are two
+    # steps, so a re-run must queue behind a run in flight, never overlap it.
+    # Job-level: other PRs closing on the release branch also start this
+    # workflow, and must not evict a queued publish (one pending per group).
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref }}
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -14,6 +14,12 @@ on:
     types: [closed]
     branches: ["release-v*"]
 
+# One publish per release branch: the tag guard and the tag push are two
+# steps, so a re-run must queue behind a run in flight, never overlap it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.base.ref }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 

--- a/.github/workflows/release-settle.yml
+++ b/.github/workflows/release-settle.yml
@@ -18,6 +18,12 @@ on:
         required: true
         type: string
 
+# One settle per version: two dispatches for the same version would both
+# force-push the same settle branch. Queue, never cancel.
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.version }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Two follow-ups from the review of stateless-validator's on-release workflow, generalised in megaeth-labs/.github#34 and applied here.

- **Concurrency groups** on every release workflow, all `cancel-in-progress: false`: one candidate at a time (`github.workflow`), one settle per version (`inputs.version`), one publish per release branch (`pull_request.base.ref`), one on-release run per tag (`github.ref`). Each ends in a push, a tag or an upload that must never be cancelled half-way, and none is atomic with its own guard, so a second run queues instead of overlapping (`--clobber` on Release assets, the tag guard-then-push in publish, the force-push of the settle branch).
- **`release-verify-version@main`** replaces the inline "binary reports the release version" step in `on-release.yml`. Same semantics (`mega-evme X.Y.Z` expected; warning on a rehearsal, hard stop on a release), and a binary that cannot run now fails the step even on a dry run instead of being reported.

**Merge after megaeth-labs/.github#34**, which adds the action. Workflow-only change; nothing under `crates/` or `bin/` is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
