### PR TITLE
ci(release): accept a base_commit on the release candidate

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -13,6 +13,11 @@ on:
         description: "Version to release (X.Y.Z)"
         required: true
         type: string
+      base_commit:
+        description: "Commit to release (blank: the tip of the default branch)"
+        required: false
+        type: string
+        default: ""
   pull_request:
     types: [closed]
     branches: [main]
@@ -53,6 +58,7 @@ jobs:
           stage: propose
           token: ${{ steps.app-token.outputs.token }}
           version: ${{ inputs.version }}
+          base_commit: ${{ inputs.base_commit }}
           version_file: Cargo.toml
           version_pattern: toml
           changelog_file: CHANGELOG.md

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -5,6 +5,11 @@ name: Release Candidate
 # opens a candidate PR. When that
 # PR merges, the `cut` job creates `release-vX.Y.Z` at the merge commit. No
 # tag is created here — see release-settle / release-publish.
+#
+# To release a commit that is not the tip of the default branch, dispatch with
+# `base_commit` as well: `propose` creates `release-vX.Y.Z` at that commit and
+# aims the candidate PR at it, so that PR never touches the default branch and
+# the `cut` job below does not run.
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
`release-candidate` gained a `base_commit` input in `megaeth-labs/.github`, for releasing a commit that is not the tip of the default branch. A `workflow_dispatch` input has to be declared in each workflow before it can be passed, so without this the feature cannot be dispatched here at all.

Two additions, matching the updated `workflow-templates/release-candidate.yml`:

- the `base_commit` dispatch input, optional and blank by default;
- passing it through to the `propose` step.

Blank keeps today's behaviour exactly: the candidate PR goes to the default branch and the `cut` job creates the release branch at the merge commit. Given a commit, `propose` cuts `release-vX.Y.Z` at that commit and aims the candidate PR at it, so the default branch is untouched and `cut` does not run.

```
gh workflow run release-candidate.yml -R OWNER/REPO --ref DEFAULT \
  -f version=X.Y.Z -f base_commit=$(git rev-parse origin/DEFAULT~4)
```

The commit must be reachable from the default branch. Note that `v*` tags are not, because settlement commits the dated changelog on the release branch. Full guide: `megaeth-labs/.github/.github/actions/RELEASE.md`, section "Releasing a commit that is not the tip".

`actionlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
